### PR TITLE
Patch to fix bag loading errors

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -10,7 +10,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 1, ContainerIDToInventoryID(1))
+                        DJBagsBagItemLoad(self, 1, C_Container.ContainerIDToInventoryID(1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -20,7 +20,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 2, ContainerIDToInventoryID(2))
+                        DJBagsBagItemLoad(self, 2, C_Container.ContainerIDToInventoryID(2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -30,7 +30,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 3, ContainerIDToInventoryID(3))
+                        DJBagsBagItemLoad(self, 3, C_Container.ContainerIDToInventoryID(3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -40,7 +40,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 4, ContainerIDToInventoryID(4))
+                        DJBagsBagItemLoad(self, 4, C_Container.ContainerIDToInventoryID(4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -155,8 +155,10 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        PanelTemplates_TabResize(self, 0);
-                        self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        if self.Text then
+                            PanelTemplates_TabResize(self, 0);
+                            self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        end
                         self.tab = 1
                     </OnLoad>
                     <OnClick>
@@ -170,8 +172,10 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        PanelTemplates_TabResize(self, 0);
-                        self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        if self.Text then
+                            PanelTemplates_TabResize(self, 0);
+                            self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        end
                         self.tab = 2
                     </OnLoad>
                     <OnClick>

--- a/src/category/Category.xml
+++ b/src/category/Category.xml
@@ -19,7 +19,7 @@
             </Layer>
         </Layers>
         <Frames>
-            <EditBox name="$parentCategoryEdit" parentKey="edit">
+            <EditBox name="$parentCategoryEdit" parentKey="edit" inherits="BackdropTemplate">
                 <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
                     <EdgeSize>
                         <AbsValue val="1" />

--- a/src/settings/CategorySettings.xml
+++ b/src/settings/CategorySettings.xml
@@ -1,7 +1,7 @@
 <Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/  http://wowprogramming.com/FrameXML/UI.xsd">
     <Script file="src/settings/CategorySettings.lua"/>
 
-    <Frame name="DJBagsCategorySettings" virtual="true" movable="true" enableMouse="true">
+    <Frame name="DJBagsCategorySettings" inherits="BackdropTemplate" virtual="true" movable="true" enableMouse="true">
         <Size x="100" y="100" />
         <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>

--- a/src/settings/Settings.xml
+++ b/src/settings/Settings.xml
@@ -2,7 +2,7 @@
 	<Script file="src/settings/Settings.lua"/>
     <Include file="src/settings/CategorySettings.xml"/>
 
-	<Frame name="DJBagsNumberSelectTemplate" virtual="true">
+    <Frame name="DJBagsNumberSelectTemplate" inherits="BackdropTemplate" virtual="true">
 		<Size y="29" />
 		<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>
@@ -66,7 +66,7 @@
 			</Button>
 		</Frames>
 	</Frame>
-    <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate" virtual="true" movable="true" enableMouse="true">
+    <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate,BackdropTemplate" virtual="true" movable="true" enableMouse="true">
     	<Size x="150" y="105" />
     	<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>


### PR DESCRIPTION
## Summary
- use C_Container.ContainerIDToInventoryID since ContainerIDToInventoryID is gone
- guard tab resize calls in the bank frame
- allow frames with backdrops by inheriting BackdropTemplate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875bc10cd14832e8415631b95bb99ef