### PR TITLE
Update backdrop syntax for 11.0

### DIFF
--- a/src/category/Category.xml
+++ b/src/category/Category.xml
@@ -20,10 +20,7 @@
         </Layers>
         <Frames>
             <EditBox name="$parentCategoryEdit" parentKey="edit" inherits="BackdropTemplate">
-                <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-                    <EdgeSize>
-                        <AbsValue val="1" />
-                    </EdgeSize>
+                <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8" edgeSize="1">
                     <Color r="0" g="0" b="0" a="0.6" />
                     <BorderColor r="0.3" g="0.3" b="0.3" a="1" />
                 </Backdrop>

--- a/src/settings/CategorySettings.xml
+++ b/src/settings/CategorySettings.xml
@@ -3,10 +3,7 @@
 
     <Frame name="DJBagsCategorySettings" inherits="BackdropTemplate" virtual="true" movable="true" enableMouse="true">
         <Size x="100" y="100" />
-        <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-            <EdgeSize>
-                <AbsValue val="1" />
-            </EdgeSize>
+        <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8" edgeSize="1">
             <Color r="0" g="0" b="0" a="0.6" />
             <BorderColor r="0.3" g="0.3" b="0.3" a="1" />
         </Backdrop>

--- a/src/settings/Settings.xml
+++ b/src/settings/Settings.xml
@@ -4,10 +4,7 @@
 
     <Frame name="DJBagsNumberSelectTemplate" inherits="BackdropTemplate" virtual="true">
 		<Size y="29" />
-		<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-            <EdgeSize>
-                <AbsValue val="1" />
-            </EdgeSize>
+		<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8" edgeSize="1">
             <Color r="0" g="0" b="0" a="0" />
             <BorderColor r="0.3" g="0.3" b="0.3" a="1" />
         </Backdrop>
@@ -68,10 +65,7 @@
 	</Frame>
     <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate,BackdropTemplate" virtual="true" movable="true" enableMouse="true">
     	<Size x="150" y="105" />
-    	<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-            <EdgeSize>
-                <AbsValue val="1" />
-            </EdgeSize>
+    	<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8" edgeSize="1">
             <Color r="0" g="0" b="0" a="0.6" />
             <BorderColor r="0.3" g="0.3" b="0.3" a="1" />
         </Backdrop>


### PR DESCRIPTION
## Summary
- fix XML backdrop definitions that broke on 11.0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875be8b6974832eb9a17e6e9d212798