### PR TITLE
Fix XML typos and missing template

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -244,7 +244,7 @@
         </Scripts>
     </Frame>
 
-    <Frame name="DJBagsBag2" inhertis="DJBagsBackgroundTemplate" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
+    <Frame name="DJBagsBag2" inherits="DJBagsBackgroundTemplate" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
            hidden="true" parent="UIParent">
         <Size x="100" y="100" />
         <Anchors>

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -149,7 +149,7 @@
                     <Anchor point="RIGHT" relativeTo="$parentDepositReagent" relativePoint="LEFT" x="-5" />
                 </Anchors>
             </EditBox>
-            <Button name="$parentTab1" inherits="TabButtonTemplate" text="BANK">
+            <Button name="$parentTab1" inherits="PanelTabButtonTemplate" text="BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parent" relativePoint="TOPLEFT" />
                 </Anchors>
@@ -166,7 +166,7 @@
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentTab2" inherits="TabButtonTemplate" text="REAGENT_BANK">
+            <Button name="$parentTab2" inherits="PanelTabButtonTemplate" text="REAGENT_BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parentTab1" relativePoint="BOTTOMRIGHT" />
                 </Anchors>


### PR DESCRIPTION
## Summary
- fix `inherits` typo in Bag.xml
- use `PanelTabButtonTemplate` instead of missing `TabButtonTemplate` in Bank.xml

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875c5f8fdac832eb24633ce2e3a7301