### PR TITLE
Fix nil CloseBankFrame call on hide

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -319,7 +319,11 @@
                 DJBagsRegisterBankFrame(self)
             </OnLoad>
             <OnHide>
-                CloseBankFrame()
+                if CloseBankFrame then
+                    CloseBankFrame()
+                elseif BankFrame and BankFrame.Hide then
+                    BankFrame:Hide()
+                end
                 StaticPopup_Hide("CONFIRM_BUY_BANK_SLOT")
             </OnHide>
         </Scripts>


### PR DESCRIPTION
## Summary
- handle missing `CloseBankFrame` when the bank UI hides

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ce9cc014832e915be05a20d8cee3