### PR TITLE
Fix: hide default bank frame

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -38,7 +38,10 @@ function DJBagsBankTab_OnClick(tab)
 end
 
 function bankFrame:BANKFRAME_OPENED()
-	self:Show()
+    self:Show()
+    if BankFrame and BankFrame.Hide then
+        BankFrame:Hide()
+    end
     DJBagsBag:Show()
 end
 


### PR DESCRIPTION
## Summary
- keep BankFrame hidden while DJBags bank is open

## Testing
- `lua` not available to run syntax checks


------
https://chatgpt.com/codex/tasks/task_e_6875cff73a64832eb11daaecb1ca068f