### PR TITLE
Fix default bank frame visibility

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -15,8 +15,13 @@ function DJBagsRegisterBankBagContainer(self, bags)
     ADDON.eventManager:Add('PLAYERBANKSLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
 
-    BankFrame:UnregisterAllEvents()
-    BankFrame:SetScript('OnShow', nil)
+    if BankFrame_LoadUI then
+        BankFrame_LoadUI()
+    end
+    if BankFrame then
+        BankFrame:UnregisterAllEvents()
+        BankFrame:SetScript('OnShow', nil)
+    end
 end
 
 function bank:BANKFRAME_OPENED()


### PR DESCRIPTION
## Summary
- ensure the Blizzard bank frame is loaded before trying to disable it

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n 1 luac -p` *(fails: `luac` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d133a5bc832ebc4a90a9a3f35b8e