### PR TITLE
Fix bank frame lingering

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -39,8 +39,15 @@ end
 
 function bankFrame:BANKFRAME_OPENED()
     self:Show()
-    if BankFrame and BankFrame.Hide then
-        BankFrame:Hide()
+    if BankFrame_LoadUI then
+        BankFrame_LoadUI()
+    end
+    if BankFrame then
+        BankFrame:UnregisterAllEvents()
+        BankFrame:SetScript('OnShow', nil)
+        if BankFrame.Hide then
+            BankFrame:Hide()
+        end
     end
     DJBagsBag:Show()
 end


### PR DESCRIPTION
## Summary
- ensure the Blizzard bank frame is loaded and fully hidden whenever the bank opens

## Testing
- `apt-get update` *(fails: internet access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875d58ac814832e9ed8bce5dca1bc2c