### PR TITLE
Add Warband bank tab

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -2,6 +2,7 @@
     <Script file="src/bank/BankFrame.lua"/>
     <Script file="src/bank/Bank.lua"/>
     <Script file="src/bank/Reagent.lua"/>
+    <Script file="src/bank/Warband.lua"/>
 
     <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" movable="true" enableMouse="true" hidden="true">
         <Size x="307" y="85" />
@@ -197,6 +198,26 @@
                     </OnClick>
                 </Scripts>
             </Button>
+            <Button name="$parentTab3" inherits="PanelTabButtonTemplate" text="WARBAND_BANK">
+                <Anchors>
+                    <Anchor point="BOTTOMLEFT" relativeTo="$parentTab2" relativePoint="BOTTOMRIGHT" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        if self.Text then
+                            PanelTemplates_TabResize(self, 0);
+                            local highlight = self.HighlightTexture or self:GetHighlightTexture();
+                            if highlight then
+                                highlight:SetWidth(self:GetTextWidth() + 31);
+                            end
+                        end
+                        self.tab = 3
+                    </OnLoad>
+                    <OnClick>
+                        DJBagsBankTab_OnClick(self)
+                    </OnClick>
+                </Scripts>
+            </Button>
             <Frame name="DJBagsBank" inherits="DJBagsBackgroundTemplate" parentKey="bankBag" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
                    hidden="true" parent="DJBagsBankBar">
                 <Anchors>
@@ -222,6 +243,23 @@
                 <Scripts>
                     <OnLoad>
                         DJBagsRegisterReagentBagContainer(self, {REAGENTBANK_CONTAINER})
+                    </OnLoad>
+                    <OnShow>
+                        self:OnShow()
+                    </OnShow>
+                    <OnHide>
+                        self:OnHide()
+                    </OnHide>
+                </Scripts>
+            </Frame>
+            <Frame name="DJBagsWarband" inherits="DJBagsBackgroundTemplate" parentKey="warbandBag" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
+                   hidden="true" parent="DJBagsBankBar">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="BOTTOMLEFT" y="-5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsRegisterWarbandBagContainer(self, {WARDBANK_CONTAINER})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()
@@ -320,10 +358,42 @@
                     </OnLoad>
                 </Scripts>
             </Frame>
+            <Frame name="$parentSettingsWarband" parentKey="warbandSettingsMenu" inherits="DJBagsSettings" hidden="true">
+                <Anchors>
+                    <Anchor point="TOP" relativeTo="$parentSettingsReagents" relativePoint="BOTTOM">
+                        <Offset>
+                            <AbsDimension y="-10"/>
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Layers>
+                    <Layer level="OVERLAY">
+                        <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight" text="WARBAND_BANK">
+                            <Anchors>
+                                <Anchor point="TOPLEFT">
+                                    <Offset>
+                                        <AbsDimension x="0" y="10"/>
+                                    </Offset>
+                                </Anchor>
+                                <Anchor point="TOPRIGHT">
+                                    <Offset>
+                                        <AbsDimension x="0" y="10"/>
+                                    </Offset>
+                                </Anchor>
+                            </Anchors>
+                        </FontString>
+                    </Layer>
+                </Layers>
+                <Scripts>
+                    <OnLoad>
+                        self.bag = self:GetParent().warbandBag
+                    </OnLoad>
+                </Scripts>
+            </Frame>
         </Frames>
         <Scripts>
             <OnLoad>
-                PanelTemplates_SetNumTabs(self, 2)
+                PanelTemplates_SetNumTabs(self, 3)
                 DJBagsRegisterBankFrame(self)
             </OnLoad>
             <OnHide>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -23,17 +23,25 @@ function DJBagsRegisterBankFrame(self, bags)
 end
 
 function DJBagsBankTab_OnClick(tab)
-	PanelTemplates_SetTab(DJBagsBankBar, tab.tab)
+        PanelTemplates_SetTab(DJBagsBankBar, tab.tab)
     if tab.tab == 1 then
         DJBagsBank:Show()
         DJBagsReagents:Hide()
+        if DJBagsWarband then DJBagsWarband:Hide() end
         BankFrame.selectedTab = 1
         BankFrame.activeTabIndex = 1
-    else
+    elseif tab.tab == 2 then
         DJBagsBank:Hide()
         DJBagsReagents:Show()
+        if DJBagsWarband then DJBagsWarband:Hide() end
         BankFrame.selectedTab = 2
         BankFrame.activeTabIndex = 2
+    else
+        DJBagsBank:Hide()
+        DJBagsReagents:Hide()
+        if DJBagsWarband then DJBagsWarband:Show() end
+        BankFrame.selectedTab = 3
+        BankFrame.activeTabIndex = 3
     end
 end
 

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -1,0 +1,31 @@
+local ADDON_NAME, ADDON = ...
+
+local bank = {}
+bank.__index = bank
+
+function DJBagsRegisterWarbandBagContainer(self, bags)
+        DJBagsRegisterBaseBagContainer(self, bags)
+
+        for k, v in pairs(bank) do
+                self[k] = v
+        end
+
+    ADDON.eventManager:Add('BANKFRAME_OPENED', self)
+    ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('PLAYERWARDBANKSLOTS_CHANGED', self)
+end
+
+function bank:BANKFRAME_OPENED()
+        if BankFrame.selectedTab == 3 then
+                self:Show()
+        end
+end
+
+function bank:BANKFRAME_CLOSED()
+        self:Hide()
+end
+
+function bank:PLAYERWARDBANKSLOTS_CHANGED()
+        self:BAG_UPDATE(WARDBANK_CONTAINER)
+end
+


### PR DESCRIPTION
## Summary
- show an extra Warband tab in the bank window
- display Warband bank items when selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875d9709ff0832ea72857a691e1de43