### PR TITLE
Fix warband bank tab item display

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -198,7 +198,7 @@
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentTab3" inherits="PanelTabButtonTemplate" text="WARBAND_BANK">
+            <Button name="$parentTab3" inherits="PanelTabButtonTemplate" text="WARBAND BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parentTab2" relativePoint="BOTTOMRIGHT" />
                 </Anchors>
@@ -368,7 +368,7 @@
                 </Anchors>
                 <Layers>
                     <Layer level="OVERLAY">
-                        <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight" text="WARBAND_BANK">
+                        <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight" text="WARBAND BANK">
                             <Anchors>
                                 <Anchor point="TOPLEFT">
                                     <Offset>

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -3,6 +3,11 @@ local ADDON_NAME, ADDON = ...
 local bank = {}
 bank.__index = bank
 
+-- Compatibility for new Warband bank container constant
+WARDBANK_CONTAINER = WARDBANK_CONTAINER
+    or (Enum.BagIndex and (Enum.BagIndex.WarbandBank or Enum.BagIndex.AccountBank))
+    or 13
+
 function DJBagsRegisterWarbandBagContainer(self, bags)
         DJBagsRegisterBaseBagContainer(self, bags)
 


### PR DESCRIPTION
## Summary
- define a fallback value for `WARDBANK_CONTAINER` so the warband bank can pull items
- update warband tab text to use a space instead of an underscore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875db679448832e905b75b4848f2961