### PR TITLE
Hide original bank UI off-screen

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -53,13 +53,20 @@ function bankFrame:BANKFRAME_OPENED()
     if BankFrame then
         BankFrame:UnregisterAllEvents()
         BankFrame:SetScript('OnShow', nil)
-        if BankFrame.Hide then
-            BankFrame:Hide()
+        if not self._bankFrameOrigPoint then
+            local point, relativeTo, relativePoint, xOfs, yOfs = BankFrame:GetPoint()
+            self._bankFrameOrigPoint = {point, relativeTo, relativePoint, xOfs, yOfs}
         end
+        BankFrame:ClearAllPoints()
+        BankFrame:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', -10000, 10000)
     end
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
-	self:Hide()
+        self:Hide()
+        if BankFrame and self._bankFrameOrigPoint then
+            BankFrame:ClearAllPoints()
+            BankFrame:SetPoint(unpack(self._bankFrameOrigPoint))
+        end
 end


### PR DESCRIPTION
## Summary
- keep track of the default BankFrame location
- move the BankFrame far off-screen while DJBags is open
- restore the position when the bank closes

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765a365d70832eaef62cf44fd32b40