### PR TITLE
Fix hiding of default bank frame

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -52,33 +52,15 @@ function bankFrame:BANKFRAME_OPENED()
     end
     if BankFrame then
         BankFrame:UnregisterAllEvents()
-        BankFrame:SetScript('OnShow', nil)
-        if not self._bankFrameOrigPoint then
-            local point, relativeTo, relativePoint, xOfs, yOfs = BankFrame:GetPoint()
-            self._bankFrameOrigPoint = {
-                point = point,
-                relativeTo = relativeTo,
-                relativePoint = relativePoint,
-                xOfs = xOfs,
-                yOfs = yOfs,
-            }
-        end
-        BankFrame:ClearAllPoints()
-        BankFrame:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', -10000, 10000)
+        BankFrame:SetScript('OnShow', BankFrame.Hide)
+        BankFrame:Hide()
     end
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
         self:Hide()
-        if BankFrame and self._bankFrameOrigPoint then
-            BankFrame:ClearAllPoints()
-            BankFrame:SetPoint(
-                self._bankFrameOrigPoint.point,
-                self._bankFrameOrigPoint.relativeTo,
-                self._bankFrameOrigPoint.relativePoint,
-                self._bankFrameOrigPoint.xOfs,
-                self._bankFrameOrigPoint.yOfs
-            )
+        if BankFrame then
+            BankFrame:SetScript('OnShow', nil)
         end
 end


### PR DESCRIPTION
## Summary
- hide the original BankFrame using `OnShow` instead of moving it offscreen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68765e00499c832ebcf208f8e8b61851