### PR TITLE
Override bank API and restore frame hiding

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -78,6 +78,27 @@ CloseBackpack = function()
     DJBagsBag:Hide()
 end
 
+-- Bank API overrides
+local oldOpenBankFrame = OpenBankFrame
+OpenBankFrame = function(...)
+    if oldOpenBankFrame then
+        oldOpenBankFrame(...)
+    end
+    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_OPENED then
+        DJBagsBankBar:BANKFRAME_OPENED()
+    end
+end
+
+local oldCloseBankFrame = CloseBankFrame
+CloseBankFrame = function(...)
+    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_CLOSED then
+        DJBagsBankBar:BANKFRAME_CLOSED()
+    end
+    if oldCloseBankFrame then
+        oldCloseBankFrame(...)
+    end
+end
+
 SLASH_DJBAGS1, SLASH_DJBAGS2, SLASH_DJBAGS3, SLASH_DJBAGS4 = '/djb', '/dj', '/djbags', '/db';
 function SlashCmdList.DJBAGS(msg, editbox)
     DJBagsBag:Show()

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -52,15 +52,33 @@ function bankFrame:BANKFRAME_OPENED()
     end
     if BankFrame then
         BankFrame:UnregisterAllEvents()
-        BankFrame:SetScript('OnShow', BankFrame.Hide)
-        BankFrame:Hide()
+        BankFrame:SetScript('OnShow', nil)
+        if not self._bankFrameOrigPoint then
+            local point, relativeTo, relativePoint, xOfs, yOfs = BankFrame:GetPoint()
+            self._bankFrameOrigPoint = {
+                point = point,
+                relativeTo = relativeTo,
+                relativePoint = relativePoint,
+                xOfs = xOfs,
+                yOfs = yOfs,
+            }
+        end
+        BankFrame:ClearAllPoints()
+        BankFrame:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', -10000, 10000)
     end
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
         self:Hide()
-        if BankFrame then
-            BankFrame:SetScript('OnShow', nil)
+        if BankFrame and self._bankFrameOrigPoint then
+            BankFrame:ClearAllPoints()
+            BankFrame:SetPoint(
+                self._bankFrameOrigPoint.point,
+                self._bankFrameOrigPoint.relativeTo,
+                self._bankFrameOrigPoint.relativePoint,
+                self._bankFrameOrigPoint.xOfs,
+                self._bankFrameOrigPoint.yOfs
+            )
         end
 end


### PR DESCRIPTION
## Summary
- restore hiding logic for the default bank frame
- hook the bank API so `OpenBankFrame` and `CloseBankFrame` open the addon bank instead

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68769a6a78cc832e8a90a7a60af7b21f