### PR TITLE
Add reagent bag support

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -1,5 +1,10 @@
 local ADDON_NAME, ADDON = ...
 
+-- Compatibility for new reagent bag container constant
+REAGENTBAG_CONTAINER = REAGENTBAG_CONTAINER
+    or (Enum.BagIndex and Enum.BagIndex.ReagentBag)
+    or 5
+
 -- Formatter types
 ADDON.formats = {
 	MASONRY = 0,

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -2,7 +2,7 @@
     <Script file="src/bag/bag.lua"/>
 
     <Frame name="DJBagsBagBarTemplate" inherits="DJBagsBackgroundTemplate" virtual="true" movable="true" enableMouse="true">
-        <Size x="183" y="58" />
+        <Size x="225" y="58" />
         <Frames>
             <ItemButton name="$parentBag1" parentKey="bag1">
                 <Anchors>
@@ -41,6 +41,16 @@
                 <Scripts>
                     <OnLoad>
                         DJBagsBagItemLoad(self, 4, C_Container.ContainerIDToInventoryID(4))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag5" parentKey="bag5">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, REAGENTBAG_CONTAINER, C_Container.ContainerIDToInventoryID(REAGENTBAG_CONTAINER))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -233,7 +243,7 @@
         </Frames>
         <Scripts>
             <OnLoad>
-                DJBagsRegisterBagBagContainer(self, {0, 1, 2, 3, 4})
+                DJBagsRegisterBagBagContainer(self, {0, 1, 2, 3, 4, REAGENTBAG_CONTAINER})
             </OnLoad>
             <OnShow>
                 self:OnShow()

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -30,7 +30,7 @@ end
 
 function item:Update()
     local numBankSlots, full = GetNumBankSlots()
-    if self.slot - NUM_BAG_SLOTS > numBankSlots  then
+    if self.slot ~= REAGENTBAG_CONTAINER and self.slot - NUM_BAG_SLOTS > numBankSlots then
         local cost = GetBankSlotCost(self.slot-1)
         self:SetCost(cost)
         return

--- a/src/category/CategoryManager.lua
+++ b/src/category/CategoryManager.lua
@@ -27,7 +27,8 @@ function categoryManager:GetTitle(item, filters)
             return setName
         end
 
-        if bag >= 0 and bag <= NUM_BAG_SLOTS and (C_NewItems.IsNewItem(bag, slot) or DJBags_DB_Char.newItems[item.id]) then
+        local isRegularBag = (bag >= 0 and bag <= NUM_BAG_SLOTS) or bag == REAGENTBAG_CONTAINER
+        if isRegularBag and (C_NewItems.IsNewItem(bag, slot) or DJBags_DB_Char.newItems[item.id]) then
           DJBags_DB_Char.newItems[item.id] = true
           return NEW
         end


### PR DESCRIPTION
## Summary
- define `REAGENTBAG_CONTAINER` for older clients
- handle reagent bag when assigning categories
- add reagent bag button to the bag bar
- load the reagent bag in the main bag container
- ignore reagent bag for bank slot purchase logic

## Testing
- `apt-get update` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6876e77a4348832e96325cd15a794baa