### PR TITLE
Fix event manager removal

### DIFF
--- a/src/event/EventManager.lua
+++ b/src/event/EventManager.lua
@@ -60,6 +60,10 @@ function eventManager:Remove(event, object)
     assert(event, 'Event required')
     assert(object, 'Object required')
 
+    if not self.events[event] then
+        return
+    end
+
     self.events[event][object] = nil
 
     if next(self.events[event]) == nil and Count(self.events[event]) == 0 then


### PR DESCRIPTION
## Summary
- safeguard event removal when the event table doesn't exist

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ec278db8832e9649f35833582f1b