### PR TITLE
Fix bank tab background style

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -158,7 +158,7 @@
                     <Anchor point="RIGHT" relativeTo="$parentDepositReagent" relativePoint="LEFT" x="-5" />
                 </Anchors>
             </EditBox>
-            <Button name="$parentTab1" inherits="PanelTabButtonTemplate,BackdropTemplate" text="BANK">
+            <Button name="$parentTab1" inherits="PanelTabButtonTemplate,BackdropTemplate,DJBagsBackgroundTemplate" text="BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parent" relativePoint="TOPLEFT" />
                 </Anchors>
@@ -172,17 +172,13 @@
                             end
                         end
                         self.tab = 1
-                        self:SetBackdrop({bgFile="Interface\\Tooltips\\UI-Tooltip-Background",
-                                        edgeFile="Interface\\Tooltips\\UI-Tooltip-Border",
-                                        tile=true, tileSize=16, edgeSize=16})
-                        self:SetBackdropColor(0,0,0,0.8)
                     </OnLoad>
                     <OnClick>
                         DJBagsBankTab_OnClick(self)
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentTab2" inherits="PanelTabButtonTemplate,BackdropTemplate" text="REAGENT_BANK">
+            <Button name="$parentTab2" inherits="PanelTabButtonTemplate,BackdropTemplate,DJBagsBackgroundTemplate" text="REAGENT_BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parentTab1" relativePoint="BOTTOMRIGHT" />
                 </Anchors>
@@ -196,17 +192,13 @@
                             end
                         end
                         self.tab = 2
-                        self:SetBackdrop({bgFile="Interface\\Tooltips\\UI-Tooltip-Background",
-                                        edgeFile="Interface\\Tooltips\\UI-Tooltip-Border",
-                                        tile=true, tileSize=16, edgeSize=16})
-                        self:SetBackdropColor(0,0,0,0.8)
                     </OnLoad>
                     <OnClick>
                         DJBagsBankTab_OnClick(self)
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentTab3" inherits="PanelTabButtonTemplate,BackdropTemplate" text="Warband Bank">
+            <Button name="$parentTab3" inherits="PanelTabButtonTemplate,BackdropTemplate,DJBagsBackgroundTemplate" text="Warband Bank">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parentTab2" relativePoint="BOTTOMRIGHT" />
                 </Anchors>
@@ -220,10 +212,6 @@
                             end
                         end
                         self.tab = 3
-                        self:SetBackdrop({bgFile="Interface\\Tooltips\\UI-Tooltip-Background",
-                                        edgeFile="Interface\\Tooltips\\UI-Tooltip-Border",
-                                        tile=true, tileSize=16, edgeSize=16})
-                        self:SetBackdropColor(0,0,0,0.8)
                     </OnLoad>
                     <OnClick>
                         DJBagsBankTab_OnClick(self)


### PR DESCRIPTION
## Summary
- match the bank tab background style with the bank frame

## Testing
- `lua -v`

------
https://chatgpt.com/codex/tasks/task_e_6876f2b8eac0832eaf6eeaac61e9e1e8