### PR TITLE
Override toast bag opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ A bag addon that sorts items into categories defined by Blizzard or user specifi
 * All bags settings for columns and categories.
 * User defined settings for all chars or per char: press ALT + Left mouse button on an item to open dialogue.
 * Clear a single new item: ALT + Right mouse button on new item to remove it from new items list.
+* Clicking Blizzard alert toasts now opens DJBags instead of the default bags.

--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -78,6 +78,15 @@ CloseBackpack = function()
     DJBagsBag:Hide()
 end
 
+local oldOpenBag = OpenBag
+OpenBag = function(id)
+    if id < 5 and id > -1 then
+        DJBagsBag:Show()
+    elseif oldOpenBag then
+        oldOpenBag(id)
+    end
+end
+
 -- Bank API overrides
 local oldOpenBankFrame = OpenBankFrame
 OpenBankFrame = function(...)


### PR DESCRIPTION
## Summary
- open DJBags when Blizzard calls `OpenBag`
- document new toast behaviour

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687872fb295c832eb28a1d95b29c1fff