### PR TITLE
Fix warband purchase button visibility

### DIFF
--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -34,7 +34,7 @@ StaticPopupDialogs["DJBAGS_CONFIRM_BUY_WARBAND_TAB"] = {
 
 function DJBagsShowWarbandTabPopup()
     local cost = GetNextPurchaseCost()
-    if cost and cost > 0 then
+    if cost and cost >= 0 then
         StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", GetCoinTextureString(cost))
     end
 end
@@ -156,7 +156,7 @@ function bank:OnShow()
     local btn = DJBagsBankBar and DJBagsBankBar.warbandPurchaseButton
     if btn then
         local cost = GetNextPurchaseCost()
-        if cost and cost > 0 then
+        if cost and cost >= 0 then
             btn.cost = cost
             btn:Show()
         else


### PR DESCRIPTION
## Summary
- ensure warband purchase button also shows when the tab cost is zero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879cb0d9994832ead378ccf64ff5648