### PR TITLE
Replace deposit all reagents with warband tab purchase

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -3,6 +3,53 @@ local ADDON_NAME, ADDON = ...
 local bankFrame = {}
 bankFrame.__index = bankFrame
 
+-- Update bank bar controls depending on the selected tab
+function DJBagsBankBar_UpdateButtons(tab)
+    local bar = DJBagsBankBar
+    if not bar then return end
+
+    local deposit = _G["DJBagsBankBarDepositReagent"]
+    local purchase = bar.warbandPurchaseButton
+    local restack = _G["DJBagsBankBarRestackButton"]
+    local search = _G["DJBagsBankBarSearchBar"]
+    local settings = _G["DJBagsBankBarSettingsBtn"]
+
+    if search and restack and settings then
+        search:ClearAllPoints()
+        search:SetPoint("LEFT", settings, "RIGHT", 5, 0)
+    end
+
+    if tab == 3 then
+        if deposit then deposit:Hide() end
+        if purchase and restack then
+            purchase:ClearAllPoints()
+            purchase:SetPoint("RIGHT", restack, "LEFT", -3, 0)
+            purchase:Show()
+        end
+        if search then
+            local anchor = purchase or restack
+            search:SetPoint("RIGHT", anchor, "LEFT", -5, 0)
+        end
+    elseif tab == 2 then
+        if purchase then purchase:Hide() end
+        if deposit and restack then
+            deposit:ClearAllPoints()
+            deposit:SetPoint("RIGHT", restack, "LEFT", -3, 0)
+            deposit:Show()
+        end
+        if search then
+            local anchor = deposit or restack
+            search:SetPoint("RIGHT", anchor, "LEFT", -5, 0)
+        end
+    else
+        if deposit then deposit:Hide() end
+        if purchase then purchase:Hide() end
+        if search and restack then
+            search:SetPoint("RIGHT", restack, "LEFT", -5, 0)
+        end
+    end
+end
+
 function DJBagsRegisterBankFrame(self, bags)
 	for k, v in pairs(bankFrame) do
 		self[k] = v
@@ -30,18 +77,21 @@ function DJBagsBankTab_OnClick(tab)
         if DJBagsWarband then DJBagsWarband:Hide() end
         BankFrame.selectedTab = 1
         BankFrame.activeTabIndex = 1
+        DJBagsBankBar_UpdateButtons(1)
     elseif tab.tab == 2 then
         DJBagsBank:Hide()
         DJBagsReagents:Show()
         if DJBagsWarband then DJBagsWarband:Hide() end
         BankFrame.selectedTab = 2
         BankFrame.activeTabIndex = 2
+        DJBagsBankBar_UpdateButtons(2)
     else
         DJBagsBank:Hide()
         DJBagsReagents:Hide()
         if DJBagsWarband then DJBagsWarband:Show() end
         BankFrame.selectedTab = 3
         BankFrame.activeTabIndex = 3
+        DJBagsBankBar_UpdateButtons(3)
     end
 end
 
@@ -51,6 +101,7 @@ function bankFrame:BANKFRAME_OPENED()
         BankFrame_LoadUI()
     end
     DJBagsBag:Show()
+    DJBagsBankBar_UpdateButtons(BankFrame.selectedTab or BankFrame.activeTabIndex or 1)
 end
 
 function bankFrame:BANKFRAME_CLOSED()

--- a/src/bank/Reagent.lua
+++ b/src/bank/Reagent.lua
@@ -57,10 +57,13 @@ function bank:OnShow()
 		end
 		self.purchaseButton:Show()
 		self:SetSize(125, 35)
-	else
-		if (self.purchaseButton) then
-			self.purchaseButton:Hide()
-		end
-		self:BaseOnShow()
-	end
+        else
+                if (self.purchaseButton) then
+                        self.purchaseButton:Hide()
+                end
+                self:BaseOnShow()
+        end
+        if DJBagsBankBar_UpdateButtons then
+                DJBagsBankBar_UpdateButtons(2)
+        end
 end

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -163,6 +163,9 @@ function bank:OnShow()
             btn:Hide()
         end
     end
+    if DJBagsBankBar_UpdateButtons then
+        DJBagsBankBar_UpdateButtons(3)
+    end
 end
 
 function bank:OnHide()


### PR DESCRIPTION
## Summary
- add `DJBagsBankBar_UpdateButtons` for controlling bank bar buttons
- call the new function when switching tabs and on bank open
- update Warband and Reagent bank OnShow to refresh the bank bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879cd107428832e9547c42a94733037