### PR TITLE
Fix warband tab purchase popup

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -134,7 +134,8 @@
                 </Anchors>
                 <Scripts>
                     <OnClick>
-                        DJBagsShowWarbandTabPopup();
+                        PlaySound(SOUNDKIT.IG_MAINMENU_OPTION);
+                        DJBagsShowWarbandTabPopup(self.cost);
                     </OnClick>
                 </Scripts>
             </Button>

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -32,8 +32,10 @@ StaticPopupDialogs["DJBAGS_CONFIRM_BUY_WARBAND_TAB"] = {
     hideOnEscape = 1,
 }
 
-function DJBagsShowWarbandTabPopup()
-    local cost = GetNextPurchaseCost()
+function DJBagsShowWarbandTabPopup(cost)
+    if not cost then
+        cost = GetNextPurchaseCost()
+    end
     if cost and cost >= 0 then
         StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", GetCoinTextureString(cost))
     end


### PR DESCRIPTION
## Summary
- ensure cost can be passed to purchase popup
- play sound and send stored cost when clicking purchase button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879cf580bcc832eb50563d7358466b6