### PR TITLE
Fix nil argument for warband purchase popup

### DIFF
--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -55,14 +55,16 @@ StaticPopupDialogs["DJBAGS_CONFIRM_BUY_WARBAND_TAB"] = {
 }
 
 function DJBagsShowWarbandTabPopup(cost)
-    if not cost or cost < 0 then
+    if cost == nil or cost < 0 then
         cost = GetNextPurchaseCost()
     end
-    if cost and cost > 0 then
-        StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", GetCoinTextureString(cost))
+    local arg
+    if cost ~= nil and cost >= 0 then
+        arg = GetCoinTextureString(cost)
     else
-        StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB")
+        arg = UNKNOWN or ""
     end
+    StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", arg)
 end
 
 -- Compatibility for new Warband bank container constant


### PR DESCRIPTION
## Summary
- prevent errors when warband bank tab cost cannot be read

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879d393e2c0832ea79c85e488c5b295