### PR TITLE
Fix warband tab popup formatting

### DIFF
--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -45,6 +45,11 @@ end
 
 StaticPopupDialogs["DJBAGS_CONFIRM_BUY_WARBAND_TAB"] = {
     text = "Buy new warband bank tab for %s?",
+    OnShow = function(self, data)
+        if data then
+            self.text:SetFormattedText(self.text:GetText(), data)
+        end
+    end,
     button1 = ACCEPT,
     button2 = CANCEL,
     OnAccept = function()
@@ -64,7 +69,7 @@ function DJBagsShowWarbandTabPopup(cost)
     else
         arg = UNKNOWN or ""
     end
-    StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", arg)
+    StaticPopup_Show("DJBAGS_CONFIRM_BUY_WARBAND_TAB", nil, nil, arg)
 end
 
 -- Compatibility for new Warband bank container constant


### PR DESCRIPTION
## Summary
- show formatted price in the warband tab popup
- ensure price argument is passed as StaticPopup data

## Testing
- `git log -1 -p`

------
https://chatgpt.com/codex/tasks/task_e_6879d6277494832e8856cb6a1c180061