### PR TITLE
Add guild bank support

### DIFF
--- a/src/bank/Guild.lua
+++ b/src/bank/Guild.lua
@@ -1,0 +1,117 @@
+local ADDON_NAME, ADDON = ...
+
+local guild = {}
+guild.__index = guild
+
+local MAX_SLOTS = MAX_GUILDBANK_SLOTS_PER_TAB or 98
+
+local function GetTabList()
+    local tabs = GetNumGuildBankTabs() or (MAX_GUILDBANK_TABS or 0)
+    local list = {}
+    for i = 1, tabs do
+        table.insert(list, i)
+    end
+    if #list == 0 then
+        list[1] = 1
+    end
+    return list
+end
+
+local function CreateContainers(self)
+    for _, tab in ipairs(self.bags) do
+        if not self.containers[tab] then
+            self.containers[tab] = CreateFrame("Frame", "DJBagsBagContainer_" .. tab, self)
+            self.containers[tab]:SetAllPoints()
+            self.containers[tab]:SetID(50 + tab)
+            self.containers[tab].items = {}
+        end
+    end
+end
+
+function DJBagsRegisterGuildBankBagContainer(self, tabs)
+    tabs = tabs or GetTabList()
+    DJBagsRegisterBaseBagContainer(self, tabs)
+
+    for k, v in pairs(guild) do
+        self[k] = v
+    end
+
+    CreateContainers(self)
+
+    ADDON.eventManager:Add('GUILDBANKFRAME_OPENED', self)
+    ADDON.eventManager:Add('GUILDBANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('GUILDBANKBAGSLOTS_CHANGED', self)
+    ADDON.eventManager:Add('GUILDBANK_UPDATE_TABS', self)
+
+    if GuildBankFrame_LoadUI then
+        GuildBankFrame_LoadUI()
+    end
+    if GuildBankFrame then
+        GuildBankFrame:UnregisterAllEvents()
+        GuildBankFrame:SetScript('OnShow', nil)
+    end
+end
+
+local function CreateTitleContainer(self, item)
+    if not self.titleContainers[item.type] then
+        self.titleContainers[item.type] = CreateFrame('Frame', string.format('DJBagsTitleContainer_%s_%s', self:GetName(), item.type), self, 'DJBagsTitleContainerTemplate')
+        self.titleContainers[item.type].name:SetText(item.type)
+        self.titleContainers[item.type].name.text = item.type
+    end
+end
+
+local function GetAllItems(self, tabs)
+    local update = false
+    for _, tab in ipairs(tabs) do
+        local container = self.containers[tab]
+        for slot = 1, MAX_SLOTS do
+            if not container.items[slot] then
+                container.items[slot] = ADDON:NewItem(container, slot, 'GuildBankItemButtonTemplate', tab)
+                table.insert(self.items, container.items[slot])
+            end
+            local item = container.items[slot]
+            local idBefore = item.id
+            item:Update()
+            item.type = ADDON.categoryManager:GetTitle(item, self.settings.filters)
+            CreateTitleContainer(self, item)
+            if idBefore ~= item.id and item.id ~= nil then
+                update = true
+            end
+        end
+    end
+    if update then
+        self:Format()
+    end
+    return update
+end
+
+function guild:Refresh()
+    if not GetAllItems(self, self.bags) then
+        self:Format()
+    end
+end
+
+function guild:GUILDBANKFRAME_OPENED()
+    for i = 1, GetNumGuildBankTabs() do
+        QueryGuildBankTab(i)
+    end
+    self:Show()
+end
+
+function guild:GUILDBANKFRAME_CLOSED()
+    self:Hide()
+end
+
+function guild:GUILDBANKBAGSLOTS_CHANGED()
+    self:Refresh()
+end
+
+function guild:GUILDBANK_UPDATE_TABS()
+    self.bags = GetTabList()
+    self.bagsByKey = {}
+    for _, tab in ipairs(self.bags) do
+        self.bagsByKey[tab] = true
+    end
+    CreateContainers(self)
+    self:Refresh()
+end

--- a/src/bank/Guild.xml
+++ b/src/bank/Guild.xml
@@ -1,0 +1,38 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/">
+    <Script file="src/bank/Guild.lua"/>
+    <Frame name="DJBagsGuildBank" inherits="DJBagsBackgroundTemplate" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true" hidden="true" parent="UIParent">
+        <Anchors>
+            <Anchor point="CENTER" />
+        </Anchors>
+        <Frames>
+            <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
+                <Anchors>
+                    <Anchor point="CENTER" relativePoint="TOPRIGHT" x="-2" y="-2"/>
+                </Anchors>
+                <NormalTexture file="Interface\\Buttons\\UI-Panel-MinimizeButton-Disabled" />
+                <Scripts>
+                    <OnLoad> self:SetAlpha(0.2) </OnLoad>
+                    <OnEnter> self:SetAlpha(1) </OnEnter>
+                    <OnLeave> self:SetAlpha(0.2) </OnLeave>
+                </Scripts>
+            </Button>
+            <EditBox name="$parentSearch" parentKey="search" inherits="BagSearchBoxTemplate">
+                <Anchors>
+                    <Anchor point="TOPLEFT" x="5" y="-5"/>
+                    <Anchor point="TOPRIGHT" x="-5" y="-5"/>
+                </Anchors>
+            </EditBox>
+        </Frames>
+        <Scripts>
+            <OnLoad>
+                DJBagsRegisterGuildBankBagContainer(self)
+            </OnLoad>
+            <OnShow>
+                self:OnShow()
+            </OnShow>
+            <OnHide>
+                self:OnHide()
+            </OnHide>
+        </Scripts>
+    </Frame>
+</Ui>

--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -56,23 +56,24 @@ local function InitItem(self, bag, slot)
     end
 end
 
-function ADDON:NewItem(parent, slot)
+function ADDON:NewItem(parent, slot, template, guildTab)
     local bag = parent:GetID()
-	assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
-	assert(slot and type(slot) == 'number', 'Slot required as integer value')
+    assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
+    assert(slot and type(slot) == 'number', 'Slot required as integer value')
 
-	local object = CreateFrame('ItemButton', string.format('DJBagsItem_%d_%d', bag, slot), parent,
-		bag == BANK_CONTAINER and 'BankItemButtonGenericTemplate' or
-            bag == REAGENTBANK_CONTAINER and 'ReagentBankItemButtonGenericTemplate' or
-            'ContainerFrameItemButtonTemplate')
+    local object = CreateFrame('ItemButton', string.format('DJBagsItem_%d_%d', bag, slot), parent,
+        template or (bag == BANK_CONTAINER and 'BankItemButtonGenericTemplate' or
+            (bag == REAGENTBANK_CONTAINER and 'ReagentBankItemButtonGenericTemplate') or
+            'ContainerFrameItemButtonTemplate'))
 
-	for k, v in pairs(item) do
-		object[k] = v
-	end
+    for k, v in pairs(item) do
+        object[k] = v
+    end
 
-	InitItem(object, bag, slot)
+    InitItem(object, bag, slot)
+    object.guildTab = guildTab
 
-	return object
+    return object
 end
 
 function item:OnClick(button)
@@ -191,16 +192,26 @@ local function OnItemUpdate(self, elapsed)
 end
 
 function item:Update()
-    local info = Container.GetContainerItemInfo(self:GetParent():GetID(), self:GetID())
+    local bag = self.guildTab or self:GetParent():GetID()
     local texture, count, locked, quality, link, filtered, id
-    if info then
-        texture = info.iconFileID
-        count = info.stackCount
-        locked = info.isLocked
-        quality = info.quality
-        link = info.hyperlink
-        filtered = info.isFiltered
-        id = info.itemID
+    if self.guildTab then
+        texture, count, locked = GetGuildBankItemInfo(self.guildTab, self:GetID())
+        link = GetGuildBankItemLink(self.guildTab, self:GetID())
+        if link then
+            id = GetItemInfoInstant(link)
+            _, _, quality = GetItemInfo(link)
+        end
+    else
+        local info = Container.GetContainerItemInfo(bag, self:GetID())
+        if info then
+            texture = info.iconFileID
+            count = info.stackCount
+            locked = info.isLocked
+            quality = info.quality
+            link = info.hyperlink
+            filtered = info.isFiltered
+            id = info.itemID
+        end
     end
     -- Only call IsEquippableItem when we have a valid item ID
     local equipable = id and IsEquippableItem(id)
@@ -210,7 +221,6 @@ function item:Update()
         name, _, _, level, _, class, subClass, _, _, _, _, classId = GetItemInfo(id)
     end
     local isEquipment = equipable or classId == LE_ITEM_CLASS_ARMOR or classId == LE_ITEM_CLASS_WEAPON
-    local bag = self:GetParent():GetID()
 
     self.id = id
     self.name = name or ''
@@ -230,7 +240,19 @@ function item:Update()
     end
 
     UpdateILevel(self, equipable, quality, level)
-    if bag == BANK_CONTAINER or bag == REAGENTBANK_CONTAINER then
+    if self.guildTab then
+        if quality and BAG_ITEM_QUALITY_COLORS[quality] then
+            self.IconBorder:Show();
+            self.IconBorder:SetVertexColor(BAG_ITEM_QUALITY_COLORS[quality].r, BAG_ITEM_QUALITY_COLORS[quality].g, BAG_ITEM_QUALITY_COLORS[quality].b);
+        else
+            self.IconBorder:Hide();
+        end
+        SetItemButtonTexture(self, texture)
+        SetItemButtonQuality(self, quality, id)
+        SetItemButtonCount(self, count)
+        SetItemButtonDesaturated(self, locked)
+        self.hasItem = id ~= nil
+    elseif bag == BANK_CONTAINER or bag == REAGENTBANK_CONTAINER then
         BankFrameItemButton_Update(self)
     else
         local questInfo1, questInfo2, questInfo3 = Container.GetContainerItemQuestInfo(bag, self:GetID())
@@ -297,20 +319,28 @@ function item:Update()
 end
 
 function item:UpdateCooldown()
-    UpdateCooldown(self)
+    if not self.guildTab then
+        UpdateCooldown(self)
+    end
 end
 
 function item:UpdateSearch()
-    local info = Container.GetContainerItemInfo(self:GetParent():GetID(), self:GetID())
-    local filtered = info and info.isFiltered
-    self:SetFiltered(filtered)
+    if not self.guildTab then
+        local info = Container.GetContainerItemInfo(self:GetParent():GetID(), self:GetID())
+        local filtered = info and info.isFiltered
+        self:SetFiltered(filtered)
+    end
 end
 
 function item:UpdateLock(locked)
     local locked = locked
     if locked == nil then
-        local info = Container.GetContainerItemInfo(self:GetParent():GetID(), self:GetID())
-        locked = info and info.isLocked
+        if self.guildTab then
+            _, _, locked = GetGuildBankItemInfo(self.guildTab, self:GetID())
+        else
+            local info = Container.GetContainerItemInfo(self:GetParent():GetID(), self:GetID())
+            locked = info and info.isLocked
+        end
     end
     SetItemButtonDesaturated(self, locked);
 end
@@ -328,3 +358,5 @@ function item:IncrementCount(count)
     self.count = self.count + count
     SetItemButtonCount(self, self.count)
 end
+
+ADDON.Item = item

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -10,6 +10,7 @@
     <Include file="src/bagItem/BagItem.xml"/>
     <Include file="src/base/Base.xml"/>
     <Include file="src/bag/Bag.xml"/>
+    <Include file="src/bank/Guild.xml"/>
     <Include file="src/bank/Bank.xml"/>
     <Script file="src/DJBags.lua"/>
 </Ui>


### PR DESCRIPTION
## Summary
- implement guild bank container
- extend item handling for guild bank items
- register guild bank XML layout
- include guild bank in manifest

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d5d8c423c832eaacc7069866a0cc5