### PR TITLE
Fix guild bank frame creation

### DIFF
--- a/src/bank/Guild.lua
+++ b/src/bank/Guild.lua
@@ -20,7 +20,7 @@ end
 local function CreateContainers(self)
     for _, tab in ipairs(self.bags) do
         if not self.containers[tab] then
-            self.containers[tab] = CreateFrame("Frame", "DJBagsBagContainer_" .. tab, self)
+            self.containers[tab] = CreateFrame("Frame", "DJBagsGuildBankContainer_" .. tab, self)
             self.containers[tab]:SetAllPoints()
             self.containers[tab]:SetID(50 + tab)
             self.containers[tab].items = {}


### PR DESCRIPTION
## Summary
- ensure unique frame names for guild bank containers

## Testing
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d610b18a8832eaaf55f05848d9753