### PR TITLE
Fix guild bank not opening DJBags

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -108,6 +108,30 @@ CloseBankFrame = function(...)
     end
 end
 
+-- Guild bank API overrides
+local oldToggleGuildBank = ToggleGuildBankFrame or ToggleGuildBankUI
+if oldToggleGuildBank then
+    ToggleGuildBankFrame = function(...)
+        oldToggleGuildBank(...)
+        if DJBagsGuildBank and DJBagsGuildBank.GUILDBANKFRAME_OPENED then
+            DJBagsGuildBank:GUILDBANKFRAME_OPENED()
+        end
+        if GuildBankFrame then
+            GuildBankFrame:Hide()
+        end
+    end
+end
+
+local oldCloseGuildBank = CloseGuildBankFrame
+if oldCloseGuildBank then
+    CloseGuildBankFrame = function(...)
+        if DJBagsGuildBank and DJBagsGuildBank.GUILDBANKFRAME_CLOSED then
+            DJBagsGuildBank:GUILDBANKFRAME_CLOSED()
+        end
+        oldCloseGuildBank(...)
+    end
+end
+
 SLASH_DJBAGS1, SLASH_DJBAGS2, SLASH_DJBAGS3, SLASH_DJBAGS4 = '/djb', '/dj', '/djbags', '/db';
 function SlashCmdList.DJBAGS(msg, editbox)
     DJBagsBag:Show()


### PR DESCRIPTION
## Summary
- hook guild bank open/close functions so DJBags shows the custom frame and hides Blizzard's window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d62e55f80832ea1df2cc7824c8ea3