### PR TITLE
Fix bank frame hiding

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -92,6 +92,9 @@ local oldOpenBankFrame = OpenBankFrame
 OpenBankFrame = function(...)
     if oldOpenBankFrame then
         oldOpenBankFrame(...)
+        if BankFrame then
+            BankFrame:Hide()
+        end
     end
     if DJBagsBankBar and DJBagsBankBar.BANKFRAME_OPENED then
         DJBagsBankBar:BANKFRAME_OPENED()

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -46,6 +46,9 @@ function DJBagsBankTab_OnClick(tab)
 end
 
 function bankFrame:BANKFRAME_OPENED()
+    if BankFrame then
+        BankFrame:Hide()
+    end
     self:Show()
     if BankFrame_LoadUI then
         BankFrame_LoadUI()


### PR DESCRIPTION
## Summary
- hide the Blizzard bank frame when DJBags opens
- ensure `OpenBankFrame` also hides the Blizzard frame

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d7aa0d6a0832eac06830b1fc417e8