### PR TITLE
Handle bank tab changes for patch 11.2

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -25,9 +25,10 @@ function DJBagsRegisterBankBagContainer(self, bags)
 end
 
 function bank:BANKFRAME_OPENED()
-	if (BankFrame.selectedTab or 1) == 1 then
-		self:Show()
-	end
+    local tab = BankFrame.activeTabIndex or BankFrame.selectedTab or 1
+    if tab == 1 then
+        self:Show()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()

--- a/src/bank/Reagent.lua
+++ b/src/bank/Reagent.lua
@@ -18,9 +18,10 @@ function DJBagsRegisterReagentBagContainer(self, bags)
 end
 
 function bank:BANKFRAME_OPENED()
-	if BankFrame.selectedTab == 2 then
-		self:Show()
-	end
+    local tab = BankFrame.activeTabIndex or BankFrame.selectedTab
+    if tab == 2 then
+        self:Show()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -85,9 +85,10 @@ function DJBagsRegisterWarbandBagContainer(self)
 end
 
 function bank:BANKFRAME_OPENED()
-        if BankFrame.selectedTab == 3 then
-                self:Show()
-        end
+    local tab = BankFrame.activeTabIndex or BankFrame.selectedTab
+    if tab == 3 then
+        self:Show()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()


### PR DESCRIPTION
## Summary
- Update bank container to respect `BankFrame.activeTabIndex` so it shows on the correct tab in patch 11.2
- Use the same tab detection for reagent and warband banks

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68927412ac08832e9eca48abffc3886f