### PR TITLE
Fix bank slot mapping after API removal

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -16,7 +16,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -26,7 +26,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -36,7 +36,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -46,7 +46,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -56,7 +56,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 5))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -66,7 +66,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 6))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -76,7 +76,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 7))
                     </OnLoad>
                 </Scripts>
             </ItemButton>

--- a/src/tooltip/Tooltip.lua
+++ b/src/tooltip/Tooltip.lua
@@ -3,11 +3,7 @@ local ADDON_NAME, ADDON = ...
 function DJBagsTooltip:GetItemLevel(bag, slot)
     self:ClearLines()
     self:SetOwner(UIParent, "ANCHOR_NONE")
-    if bag < 0 then
-        self:SetInventoryItem("player", BankButtonIDToInvSlotID(slot))
-    else
-        self:SetBagItem(bag, slot)
-    end
+    self:SetBagItem(bag, slot)
 
     for i = 2, self:NumLines() do
         local text = _G[self:GetName() .. "TextLeft" .. i]:GetText()
@@ -26,11 +22,7 @@ end
 function DJBagsTooltip:IsItemBOE(bag, slot)
     self:ClearLines()
     self:SetOwner(UIParent, "ANCHOR_NONE")
-    if bag < 0 then
-        self:SetInventoryItem("player", BankButtonIDToInvSlotID(slot))
-    else
-        self:SetBagItem(bag, slot)
-    end
+    self:SetBagItem(bag, slot)
 
 
     for i = 2, self:NumLines() do
@@ -47,11 +39,7 @@ end
 function DJBagsTooltip:IsItemBOA(bag, slot)
     self:ClearLines()
     self:SetOwner(UIParent, "ANCHOR_NONE")
-    if bag < 0 then
-        self:SetInventoryItem("player", BankButtonIDToInvSlotID(slot))
-    else
-        self:SetBagItem(bag, slot)
-    end
+    self:SetBagItem(bag, slot)
 
     for i = 2, self:NumLines() do
         local text = _G[self:GetName() .. "TextLeft" .. i]:GetText()
@@ -68,11 +56,7 @@ end
 function DJBagsTooltip:IsItemBOBA(bag, slot)
     self:ClearLines()
     self:SetOwner(UIParent, "ANCHOR_NONE")
-    if bag < 0 then
-        self:SetInventoryItem("player", BankButtonIDToInvSlotID(slot))
-    else
-        self:SetBagItem(bag, slot)
-    end
+    self:SetBagItem(bag, slot)
 
     for i = 2, self:NumLines() do
         local text = _G[self:GetName() .. "TextLeft" .. i]:GetText()


### PR DESCRIPTION
## Summary
- use `C_Container.ContainerIDToInventoryID` when initializing bank bag buttons
- rely on `SetBagItem` for tooltips instead of removed `BankButtonIDToInvSlotID`

## Testing
- `luac -p src/tooltip/Tooltip.lua` *(command not found)*
- `xmllint src/bank/Bank.xml` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689275798894832e83bea4b0dd0553f8