### PR TITLE
Use container ID helper for bag slots

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -10,7 +10,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 1, C_Container.ContainerIDToInventoryID(1))
+                        DJBagsBagItemLoad(self, 1, DJBagsContainerIDToInventoryID(1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -20,7 +20,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 2, C_Container.ContainerIDToInventoryID(2))
+                        DJBagsBagItemLoad(self, 2, DJBagsContainerIDToInventoryID(2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -30,7 +30,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 3, C_Container.ContainerIDToInventoryID(3))
+                        DJBagsBagItemLoad(self, 3, DJBagsContainerIDToInventoryID(3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -40,7 +40,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 4, C_Container.ContainerIDToInventoryID(4))
+                        DJBagsBagItemLoad(self, 4, DJBagsContainerIDToInventoryID(4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -50,7 +50,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, REAGENTBAG_CONTAINER, C_Container.ContainerIDToInventoryID(REAGENTBAG_CONTAINER))
+                        DJBagsBagItemLoad(self, REAGENTBAG_CONTAINER, DJBagsContainerIDToInventoryID(REAGENTBAG_CONTAINER))
                     </OnLoad>
                 </Scripts>
             </ItemButton>

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -2,6 +2,17 @@ local NAME, ADDON = ...
 
 local item = {}
 
+function DJBagsContainerIDToInventoryID(bagID)
+    if C_Container and C_Container.ContainerIDToInventoryID then
+        return C_Container.ContainerIDToInventoryID(bagID)
+    elseif ContainerIDToInventoryID then
+        return ContainerIDToInventoryID(bagID)
+    elseif BankButtonIDToInvSlotID then
+        return BankButtonIDToInvSlotID(bagID)
+    end
+    return bagID
+end
+
 function DJBagsBagItemLoad(button, slot, id)
     for k, v in pairs(item) do
         button[k] = v

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -16,7 +16,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 1))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -26,7 +26,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 2))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -36,7 +36,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 3))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -46,7 +46,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 4))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -56,7 +56,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 5))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 5))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -66,7 +66,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 6))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 6))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -76,7 +76,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + 7))
+                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 7))
                     </OnLoad>
                 </Scripts>
             </ItemButton>


### PR DESCRIPTION
## Summary
- Provide helper `DJBagsContainerIDToInventoryID` to map container IDs to inventory slot IDs using the available API
- Update bag and bank XML to rely on helper instead of removed `BankButtonIDToInvSlotID`

## Testing
- `luacheck .` *(fails: command not found)*
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: luac not found)*

------
https://chatgpt.com/codex/tasks/task_e_689276eaff18832e80528b4b38220e1d