### PR TITLE
Replace bank bag slots with bank tab buttons

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -40,11 +40,7 @@ function bank:PLAYERBANKSLOTS_CHANGED()
 end
 
 function bank:BAG_UPDATE_DELAYED()
-    for _, bag in pairs(self.bags) do
-    	if bag ~= BANK_CONTAINER then
-			DJBagsBankBar['bag' .. bag - NUM_BAG_SLOTS]:Update()
-		end
-	end
+    -- Bank tabs handle their own updates; no bag slot buttons to refresh.
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -10,80 +10,45 @@
             <Anchor point="TOPLEFT" x="150" y="-100" />
         </Anchors>
         <Frames>
-            <ItemButton name="$parentBag1" parentKey="bag1">
+            <Button name="$parentBankTab1" parentKey="bankTab1" inherits="BankTabButtonTemplate" id="1">
                 <Anchors>
                     <Anchor point="TOPLEFT" x="9" y="-9" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag2" parentKey="bag2">
+            </Button>
+            <Button name="$parentBankTab2" parentKey="bankTab2" inherits="BankTabButtonTemplate" id="2">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab1" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 2))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag3" parentKey="bag3">
+            </Button>
+            <Button name="$parentBankTab3" parentKey="bankTab3" inherits="BankTabButtonTemplate" id="3">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag2" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab2" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 3))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag4" parentKey="bag4">
+            </Button>
+            <Button name="$parentBankTab4" parentKey="bankTab4" inherits="BankTabButtonTemplate" id="4">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag3" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab3" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 4))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag5" parentKey="bag5">
+            </Button>
+            <Button name="$parentBankTab5" parentKey="bankTab5" inherits="BankTabButtonTemplate" id="5">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab4" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 5))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag6" parentKey="bag6">
+            </Button>
+            <Button name="$parentBankTab6" parentKey="bankTab6" inherits="BankTabButtonTemplate" id="6">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag5" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab5" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 6))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag7" parentKey="bag7">
+            </Button>
+            <Button name="$parentBankTab7" parentKey="bankTab7" inherits="BankTabButtonTemplate" id="7">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag6" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab6" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, DJBagsContainerIDToInventoryID(NUM_BAG_SLOTS + 7))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
+            </Button>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag7" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" relativeTo="$parentBankTab7" relativePoint="BOTTOMRIGHT" y="-9.5" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -130,7 +95,7 @@
             <Button name="$parentSettingsBtn">
                 <Size x="16" y="16"/>
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="BOTTOMLEFT" x="0" y="-5"/>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBankTab1" relativePoint="BOTTOMLEFT" x="0" y="-5"/>
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled"/>
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up"/>


### PR DESCRIPTION
## Summary
- replace bank bag item buttons with bank tab buttons in the bank bar
- anchor restack and settings controls to new bank tabs
- drop obsolete bag slot update logic

## Testing
- `luac -p src/bank/Bank.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689282bcec3c832ebcb5e5a8dafb439b