### PR TITLE
Fix missing ItemButtonTemplate for bank tab buttons

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -10,8 +10,16 @@
         minimal replacement that mimics an item button so the bank bar can
         create its tab buttons without relying on Blizzard's template.
     -->
-    <Button name="DJBagsBankTabButtonTemplate" inherits="ItemButtonTemplate" virtual="true">
+    <Button name="DJBagsBankTabButtonTemplate" virtual="true">
         <Size x="40" y="40" />
+        <Layers>
+            <Layer level="BACKGROUND">
+                <Texture name="$parentIconTexture" setAllPoints="true" />
+            </Layer>
+        </Layers>
+        <NormalTexture file="Interface\Buttons\UI-Quickslot2" />
+        <PushedTexture file="Interface\Buttons\UI-Quickslot-Depress" />
+        <HighlightTexture file="Interface\Buttons\ButtonHilight-Square" alphaMode="ADD" />
     </Button>
 
     <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" movable="true" enableMouse="true" hidden="true">


### PR DESCRIPTION
## Summary
- Provide a standalone `DJBagsBankTabButtonTemplate` with icon, normal, pushed, and highlight textures
- Remove reliance on Blizzard's removed `ItemButtonTemplate`

## Testing
- `python - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('src/bank/Bank.xml')\nprint('XML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_689286223648832ebcc277c0d5a52395