### PR TITLE
Fix bank tab count font for latest WoW UI

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -17,9 +17,7 @@
                 <Texture name="$parentIconTexture" setAllPoints="true" />
             </Layer>
             <Layer level="OVERLAY">
-                <FontString name="$parentCount" parentKey="Count" setAllPoints="true" justifyH="RIGHT" justifyV="BOTTOM">
-                    <Font height="13">NumberFontNormal</Font>
-                </FontString>
+                <FontString name="$parentCount" parentKey="Count" setAllPoints="true" justifyH="RIGHT" justifyV="BOTTOM" inherits="NumberFontNormal"/>
             </Layer>
         </Layers>
         <NormalTexture file="Interface\Buttons\UI-Quickslot2" />


### PR DESCRIPTION
## Summary
- replace deprecated `<Font>` tag in bank tab template with `FontString` inherit to avoid XML parsing error

## Testing
- `xmllint --noout src/bank/Bank.xml` *(command not found)*
- `lua -v` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68928d4c915c832e8b3051b2125b130c