### PR TITLE
Add IconBorder texture to bank tab buttons

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -17,6 +17,8 @@
                 <Texture name="$parentIconTexture" setAllPoints="true" />
             </Layer>
             <Layer level="OVERLAY">
+                <!-- Item buttons expect an IconBorder texture for quality coloring. -->
+                <Texture name="$parentIconBorder" parentKey="IconBorder" inherits="IconBorderTemplate" setAllPoints="true" hidden="true" />
                 <FontString name="$parentCount" parentKey="Count" setAllPoints="true" justifyH="RIGHT" justifyV="BOTTOM" inherits="NumberFontNormal"/>
             </Layer>
         </Layers>


### PR DESCRIPTION
## Summary
- add IconBorder texture to custom bank tab template so ItemButton helpers can color quality

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689290a66120832eb19c1e75f322946f