### PR TITLE
fix: replace IconBorderTemplate inheritance

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -18,7 +18,7 @@
             </Layer>
             <Layer level="OVERLAY">
                 <!-- Item buttons expect an IconBorder texture for quality coloring. -->
-                <Texture name="$parentIconBorder" parentKey="IconBorder" inherits="IconBorderTemplate" setAllPoints="true" hidden="true" />
+                <Texture name="$parentIconBorder" parentKey="IconBorder" file="Interface\\Buttons\\UI-ActionButton-Border" blendMode="ADD" setAllPoints="true" hidden="true" />
                 <FontString name="$parentCount" parentKey="Count" setAllPoints="true" justifyH="RIGHT" justifyV="BOTTOM" inherits="NumberFontNormal"/>
             </Layer>
         </Layers>


### PR DESCRIPTION
## Summary
- use an explicit UI-ActionButton-Border texture for bank tab icon borders

## Testing
- `xmllint --noout src/bank/Bank.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689291b899b4832e87877840049cf857