### PR TITLE
Fix bank icon border attribute

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -18,7 +18,7 @@
             </Layer>
             <Layer level="OVERLAY">
                 <!-- Item buttons expect an IconBorder texture for quality coloring. -->
-                <Texture name="$parentIconBorder" parentKey="IconBorder" file="Interface\\Buttons\\UI-ActionButton-Border" blendMode="ADD" setAllPoints="true" hidden="true" />
+                <Texture name="$parentIconBorder" parentKey="IconBorder" file="Interface\\Buttons\\UI-ActionButton-Border" alphaMode="ADD" setAllPoints="true" hidden="true" />
                 <FontString name="$parentCount" parentKey="Count" setAllPoints="true" justifyH="RIGHT" justifyV="BOTTOM" inherits="NumberFontNormal"/>
             </Layer>
         </Layers>


### PR DESCRIPTION
## Summary
- replace unrecognized `blendMode` with `alphaMode` for bank icon border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689292e00bd8832e96101b36cec4f7fa