### PR TITLE
Hide default bank frame when banker is interacted

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -93,6 +93,9 @@ OpenBankFrame = function(...)
     if oldOpenBankFrame then
         oldOpenBankFrame(...)
     end
+    if BankFrame and BankFrame:IsShown() then
+        BankFrame:Hide()
+    end
     if DJBagsBankBar and DJBagsBankBar.BANKFRAME_OPENED then
         DJBagsBankBar:BANKFRAME_OPENED()
     end


### PR DESCRIPTION
## Summary
- ensure the Blizzard bank frame is hidden so only DJBags bank UI opens

## Testing
- `luac -p src/DJBags.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689297b507e8832e8f733e6b11e3b899