### PR TITLE
Fix bank frame visibility

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -20,7 +20,7 @@ function DJBagsRegisterBankBagContainer(self, bags)
     end
     if BankFrame then
         BankFrame:UnregisterAllEvents()
-        BankFrame:SetScript('OnShow', nil)
+        BankFrame:SetScript('OnShow', BankFrame.Hide)
     end
 end
 


### PR DESCRIPTION
## Summary
- hide Blizzard bank frame when it tries to open

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68929a156154832eab7b08bbf245ed11