### PR TITLE
Fix bank frame reopening

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -111,6 +111,19 @@ CloseBankFrame = function(...)
     end
 end
 
+-- When the bank is closed by the game (e.g. walking away from the banker),
+-- the default UI still expects CloseBankFrame to run so its internal state is
+-- reset.  Since DJBags suppresses the default frame, listen for the
+-- BANKFRAME_CLOSED event and invoke the original CloseBankFrame to allow the
+-- bank to be opened again without reloading the UI.
+local bankEvents = CreateFrame('Frame')
+bankEvents:RegisterEvent('BANKFRAME_CLOSED')
+bankEvents:SetScript('OnEvent', function()
+    if oldCloseBankFrame then
+        oldCloseBankFrame()
+    end
+end)
+
 SLASH_DJBAGS1, SLASH_DJBAGS2, SLASH_DJBAGS3, SLASH_DJBAGS4 = '/djb', '/dj', '/djbags', '/db';
 function SlashCmdList.DJBAGS(msg, editbox)
     DJBagsBag:Show()


### PR DESCRIPTION
## Summary
- Ensure the default CloseBankFrame runs when the bank closes so the bank can be reopened without reloading UI.

## Testing
- `luac -p src/DJBags.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892a03cbd10832ebbc6c09fb1efc2af