### PR TITLE
Handle new bank open/close events

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -96,15 +96,23 @@ OpenBankFrame = function(...)
     if BankFrame and BankFrame:IsShown() then
         BankFrame:Hide()
     end
-    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_OPENED then
-        DJBagsBankBar:BANKFRAME_OPENED()
+    if DJBagsBankBar then
+        if DJBagsBankBar.BANK_OPENED then
+            DJBagsBankBar:BANK_OPENED()
+        elseif DJBagsBankBar.BANKFRAME_OPENED then
+            DJBagsBankBar:BANKFRAME_OPENED()
+        end
     end
 end
 
 local oldCloseBankFrame = CloseBankFrame
 CloseBankFrame = function(...)
-    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_CLOSED then
-        DJBagsBankBar:BANKFRAME_CLOSED()
+    if DJBagsBankBar then
+        if DJBagsBankBar.BANK_CLOSED then
+            DJBagsBankBar:BANK_CLOSED()
+        elseif DJBagsBankBar.BANKFRAME_CLOSED then
+            DJBagsBankBar:BANKFRAME_CLOSED()
+        end
     end
     if oldCloseBankFrame then
         oldCloseBankFrame(...)
@@ -118,6 +126,7 @@ end
 -- bank to be opened again without reloading the UI.
 local bankEvents = CreateFrame('Frame')
 bankEvents:RegisterEvent('BANKFRAME_CLOSED')
+bankEvents:RegisterEvent('BANK_CLOSED')
 bankEvents:SetScript('OnEvent', function()
     if oldCloseBankFrame then
         oldCloseBankFrame()

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -12,6 +12,8 @@ function DJBagsRegisterBankBagContainer(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('BANK_OPENED', self)
+    ADDON.eventManager:Add('BANK_CLOSED', self)
     ADDON.eventManager:Add('PLAYERBANKSLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
 
@@ -30,10 +32,12 @@ function bank:BANKFRAME_OPENED()
         self:Show()
     end
 end
+bank.BANK_OPENED = bank.BANKFRAME_OPENED
 
 function bank:BANKFRAME_CLOSED()
-	self:Hide()
+        self:Hide()
 end
+bank.BANK_CLOSED = bank.BANKFRAME_CLOSED
 
 function bank:PLAYERBANKSLOTS_CHANGED()
 	self:BAG_UPDATE(BANK_CONTAINER)

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -10,6 +10,8 @@ function DJBagsRegisterBankFrame(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('BANK_OPENED', self)
+    ADDON.eventManager:Add('BANK_CLOSED', self)
 
     table.insert(UISpecialFrames, self:GetName())
     self:RegisterForDrag("LeftButton")
@@ -44,7 +46,9 @@ function bankFrame:BANKFRAME_OPENED()
     end
     DJBagsBag:Show()
 end
+bankFrame.BANK_OPENED = bankFrame.BANKFRAME_OPENED
 
 function bankFrame:BANKFRAME_CLOSED()
     self:Hide()
 end
+bankFrame.BANK_CLOSED = bankFrame.BANKFRAME_CLOSED

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -81,6 +81,8 @@ function DJBagsRegisterWarbandBagContainer(self)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('BANK_OPENED', self)
+    ADDON.eventManager:Add('BANK_CLOSED', self)
     ADDON.eventManager:Add('PLAYERWARDBANKSLOTS_CHANGED', self)
 end
 
@@ -90,10 +92,12 @@ function bank:BANKFRAME_OPENED()
         self:Show()
     end
 end
+bank.BANK_OPENED = bank.BANKFRAME_OPENED
 
 function bank:BANKFRAME_CLOSED()
         self:Hide()
 end
+bank.BANK_CLOSED = bank.BANKFRAME_CLOSED
 
 function bank:PLAYERWARDBANKSLOTS_CHANGED()
     UpdateBagList(self)


### PR DESCRIPTION
## Summary
- listen for BANK_OPENED and BANK_CLOSED in bank-related frames
- map new events to existing bank open/close handlers
- update bank overrides to invoke new events and react to both signals

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*
- `sudo apt-get install -y lua5.1` *(fails: Unable to locate package lua5.1)*

------
https://chatgpt.com/codex/tasks/task_e_6892a24719f4832eb0cd4b06f74d8b1a