### PR TITLE
Handle bank frame events correctly

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -96,23 +96,15 @@ OpenBankFrame = function(...)
     if BankFrame and BankFrame:IsShown() then
         BankFrame:Hide()
     end
-    if DJBagsBankBar then
-        if DJBagsBankBar.BANK_OPENED then
-            DJBagsBankBar:BANK_OPENED()
-        elseif DJBagsBankBar.BANKFRAME_OPENED then
-            DJBagsBankBar:BANKFRAME_OPENED()
-        end
+    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_OPENED then
+        DJBagsBankBar:BANKFRAME_OPENED()
     end
 end
 
 local oldCloseBankFrame = CloseBankFrame
 CloseBankFrame = function(...)
-    if DJBagsBankBar then
-        if DJBagsBankBar.BANK_CLOSED then
-            DJBagsBankBar:BANK_CLOSED()
-        elseif DJBagsBankBar.BANKFRAME_CLOSED then
-            DJBagsBankBar:BANKFRAME_CLOSED()
-        end
+    if DJBagsBankBar and DJBagsBankBar.BANKFRAME_CLOSED then
+        DJBagsBankBar:BANKFRAME_CLOSED()
     end
     if oldCloseBankFrame then
         oldCloseBankFrame(...)
@@ -126,7 +118,6 @@ end
 -- bank to be opened again without reloading the UI.
 local bankEvents = CreateFrame('Frame')
 bankEvents:RegisterEvent('BANKFRAME_CLOSED')
-bankEvents:RegisterEvent('BANK_CLOSED')
 bankEvents:SetScript('OnEvent', function()
     if oldCloseBankFrame then
         oldCloseBankFrame()

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -12,8 +12,6 @@ function DJBagsRegisterBankBagContainer(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
-    ADDON.eventManager:Add('BANK_OPENED', self)
-    ADDON.eventManager:Add('BANK_CLOSED', self)
     ADDON.eventManager:Add('PLAYERBANKSLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
 
@@ -32,12 +30,10 @@ function bank:BANKFRAME_OPENED()
         self:Show()
     end
 end
-bank.BANK_OPENED = bank.BANKFRAME_OPENED
 
 function bank:BANKFRAME_CLOSED()
         self:Hide()
 end
-bank.BANK_CLOSED = bank.BANKFRAME_CLOSED
 
 function bank:PLAYERBANKSLOTS_CHANGED()
 	self:BAG_UPDATE(BANK_CONTAINER)

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -10,8 +10,6 @@ function DJBagsRegisterBankFrame(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
-    ADDON.eventManager:Add('BANK_OPENED', self)
-    ADDON.eventManager:Add('BANK_CLOSED', self)
 
     table.insert(UISpecialFrames, self:GetName())
     self:RegisterForDrag("LeftButton")
@@ -46,9 +44,7 @@ function bankFrame:BANKFRAME_OPENED()
     end
     DJBagsBag:Show()
 end
-bankFrame.BANK_OPENED = bankFrame.BANKFRAME_OPENED
 
 function bankFrame:BANKFRAME_CLOSED()
     self:Hide()
 end
-bankFrame.BANK_CLOSED = bankFrame.BANKFRAME_CLOSED

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -81,8 +81,6 @@ function DJBagsRegisterWarbandBagContainer(self)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
-    ADDON.eventManager:Add('BANK_OPENED', self)
-    ADDON.eventManager:Add('BANK_CLOSED', self)
     ADDON.eventManager:Add('PLAYERWARDBANKSLOTS_CHANGED', self)
 end
 
@@ -92,12 +90,10 @@ function bank:BANKFRAME_OPENED()
         self:Show()
     end
 end
-bank.BANK_OPENED = bank.BANKFRAME_OPENED
 
 function bank:BANKFRAME_CLOSED()
         self:Hide()
 end
-bank.BANK_CLOSED = bank.BANKFRAME_CLOSED
 
 function bank:PLAYERWARDBANKSLOTS_CHANGED()
     UpdateBagList(self)


### PR DESCRIPTION
## Summary
- remove registration for nonexistent BANK_OPENED/BANK_CLOSED events
- register only BANKFRAME_OPENED and BANKFRAME_CLOSED

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892a40b9c18832ebf4074dde29975c4