### PR TITLE
Close bank frame when hidden to restore Escape key

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -20,6 +20,10 @@ function DJBagsRegisterBankFrame(self, bags)
         self:StopMovingOrSizing(...)
     end)
     self:SetUserPlaced(true)
+
+    self:HookScript("OnHide", function()
+        CloseBankFrame()
+    end)
 end
 
 function DJBagsBankTab_OnClick(tab)


### PR DESCRIPTION
## Summary
- Close the bank frame when hidden so Escape can open the game menu again.

## Testing
- `luac -p src/bank/BankFrame.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc346560832e8c983711e1d327b1