### PR TITLE
Avoid calling missing CloseBankFrame in DJBags

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -30,7 +30,11 @@ function DJBagsRegisterBankFrame(self, bags)
                 BankFrame:SetScript('OnShow', nil)
                 BankFrame:Show()
             end
-            CloseBankFrame()
+            if type(CloseBankFrame) == 'function' then
+                CloseBankFrame()
+            elseif BankFrame then
+                BankFrame:Hide()
+            end
             if restoreOnShow then
                 BankFrame:SetScript('OnShow', BankFrame.Hide)
             end


### PR DESCRIPTION
## Summary
- Safely close the default bank frame by checking for `CloseBankFrame` and falling back to hiding the frame when it is unavailable.

## Testing
- `luacheck --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `luac -p DJBags/src/bank/BankFrame.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c79dc5a0832ea4409df0af31c2fc