### PR TITLE
Fix Warband bank tab detection

### DIFF
--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -5,7 +5,7 @@ bank.__index = bank
 
 -- Compatibility for new Warband bank container constant
 WARDBANK_CONTAINER = WARDBANK_CONTAINER
-    or (Enum.BagIndex and (Enum.BagIndex.WarbandBank or Enum.BagIndex.AccountBank))
+    or (Enum.BagIndex and (Enum.BagIndex.AccountBankTab1 or Enum.BagIndex.WarbandBank or Enum.BagIndex.AccountBank))
     or 13
 
 


### PR DESCRIPTION
## Summary
- ensure Warband bank tab uses current container ID

## Testing
- `luacheck .` *(fails: command not found)*
- `lua -p src/bank/Warband.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895412c48c8832ebb183116ec14be10