### PR TITLE
Fix bank frame tab selection and warband view

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -64,6 +64,13 @@ function bankFrame:BANKFRAME_OPENED()
         BankFrame_LoadUI()
     end
     DJBagsBag:Show()
+    -- Select the main bank tab by default when the bank opens so that the
+    -- contents are visible without requiring an additional click.  This also
+    -- ensures other tabs (such as the Warband bank) start hidden and only show
+    -- when explicitly selected.
+    if DJBagsBankBarTab1 and DJBagsBankTab_OnClick then
+        DJBagsBankTab_OnClick(DJBagsBankBarTab1)
+    end
 end
 
 function bankFrame:BANKFRAME_CLOSED()

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -90,8 +90,11 @@ function bank:BANKFRAME_OPENED()
     -- bank frame. The previous check against tab index 3 prevented the
     -- warband container from showing when it was the active tab,
     -- leaving the frame hidden until the user reselected the tab. Use
-    -- the correct tab index so the warband bank loads reliably.
+    -- the correct tab index so the warband bank loads reliably. When the
+    -- warband tab is active on open, refresh the bag list before showing so
+    -- the items populate immediately.
     if tab == 2 then
+        UpdateBagList(self)
         self:Show()
     end
 end


### PR DESCRIPTION
## Summary
- Default to the main bank tab when opening the bank frame
- Refresh Warband bank container so tab shows items correctly

## Testing
- `luac -p src/bank/BankFrame.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689542c7ceb8832eb78e05246b92d2e9