### PR TITLE
Restore bank opening via Player Interaction events

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -3,6 +3,16 @@ local ADDON_NAME, ADDON = ...
 local bank = {}
 bank.__index = bank
 
+local bankInteractions = {}
+if Enum and Enum.PlayerInteractionType then
+    if Enum.PlayerInteractionType.Banker then
+        bankInteractions[Enum.PlayerInteractionType.Banker] = true
+    end
+    if Enum.PlayerInteractionType.AccountBanker then
+        bankInteractions[Enum.PlayerInteractionType.AccountBanker] = true
+    end
+end
+
 function DJBagsRegisterBankBagContainer(self, bags)
 	DJBagsRegisterBaseBagContainer(self, bags)
 
@@ -12,6 +22,8 @@ function DJBagsRegisterBankBagContainer(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_SHOW', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_HIDE', self)
     ADDON.eventManager:Add('PLAYERBANKSLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
 
@@ -61,4 +73,16 @@ function bank:SortBags()
         SortBankBags()
     end
     ADDON.eventManager:Add('BAG_UPDATE', self)
+end
+
+function bank:PLAYER_INTERACTION_MANAGER_FRAME_SHOW(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_OPENED()
+	end
+end
+
+function bank:PLAYER_INTERACTION_MANAGER_FRAME_HIDE(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_CLOSED()
+	end
 end

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -2,6 +2,15 @@ local ADDON_NAME, ADDON = ...
 
 local bankFrame = {}
 bankFrame.__index = bankFrame
+local bankInteractions = {}
+if Enum and Enum.PlayerInteractionType then
+	if Enum.PlayerInteractionType.Banker then
+		bankInteractions[Enum.PlayerInteractionType.Banker] = true
+	end
+	if Enum.PlayerInteractionType.AccountBanker then
+		bankInteractions[Enum.PlayerInteractionType.AccountBanker] = true
+	end
+end
 
 function DJBagsRegisterBankFrame(self, bags)
 	for k, v in pairs(bankFrame) do
@@ -10,6 +19,8 @@ function DJBagsRegisterBankFrame(self, bags)
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_SHOW', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_HIDE', self)
 
     table.insert(UISpecialFrames, self:GetName())
     self:RegisterForDrag("LeftButton")
@@ -74,5 +85,17 @@ function bankFrame:BANKFRAME_OPENED()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
-    self:Hide()
+	self:Hide()
+end
+
+function bankFrame:PLAYER_INTERACTION_MANAGER_FRAME_SHOW(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_OPENED()
+	end
+end
+
+function bankFrame:PLAYER_INTERACTION_MANAGER_FRAME_HIDE(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_CLOSED()
+	end
 end

--- a/src/bank/Warband.lua
+++ b/src/bank/Warband.lua
@@ -3,6 +3,16 @@ local ADDON_NAME, ADDON = ...
 local bank = {}
 bank.__index = bank
 
+local bankInteractions = {}
+if Enum and Enum.PlayerInteractionType then
+	if Enum.PlayerInteractionType.Banker then
+		bankInteractions[Enum.PlayerInteractionType.Banker] = true
+	end
+	if Enum.PlayerInteractionType.AccountBanker then
+		bankInteractions[Enum.PlayerInteractionType.AccountBanker] = true
+	end
+end
+
 -- Compatibility for new Warband bank container constant
 WARDBANK_CONTAINER = WARDBANK_CONTAINER
     or (Enum.BagIndex and (Enum.BagIndex.AccountBankTab1 or Enum.BagIndex.WarbandBank or Enum.BagIndex.AccountBank))
@@ -115,6 +125,8 @@ function DJBagsRegisterWarbandBagContainer(self)
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
     ADDON.eventManager:Add('PLAYERWARDBANKSLOTS_CHANGED', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_SHOW', self)
+    ADDON.eventManager:Add('PLAYER_INTERACTION_MANAGER_FRAME_HIDE', self)
 end
 
 function bank:BANKFRAME_OPENED()
@@ -155,10 +167,22 @@ function bank:SortBags()
 end
 
 function bank:OnShow()
-    FetchWarbandBank()
-    UpdateBagList(self)
-    if self.BaseOnShow then
-        self:BaseOnShow()
-    end
+	FetchWarbandBank()
+	UpdateBagList(self)
+	if self.BaseOnShow then
+		self:BaseOnShow()
+	end
+end
+
+function bank:PLAYER_INTERACTION_MANAGER_FRAME_SHOW(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_OPENED()
+	end
+end
+
+function bank:PLAYER_INTERACTION_MANAGER_FRAME_HIDE(interactionType)
+	if bankInteractions[interactionType] then
+		self:BANKFRAME_CLOSED()
+	end
 end
 


### PR DESCRIPTION
## Summary
- Listen for Player Interaction Manager events so DJBags opens or closes when talking to bankers
- Handle the new events for both personal and warband banks

## Testing
- `luac -p src/bank/Bank.lua src/bank/BankFrame.lua src/bank/Warband.lua`


------
https://chatgpt.com/codex/tasks/task_e_68954b630338832ea58780b577a1da47