### PR TITLE
Ensure warband bank loads when tab is selected

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -63,7 +63,14 @@ function DJBagsBankTab_OnClick(tab)
         BankFrame.activeTabIndex = 1
     else
         DJBagsBank:Hide()
-        if DJBagsWarband then DJBagsWarband:Show() end
+        if DJBagsWarband then
+            DJBagsWarband:Show()
+            -- Explicitly refresh the warband bank when its tab is selected so
+            -- the container and items populate immediately.
+            if DJBagsWarband.BANKFRAME_OPENED then
+                DJBagsWarband:BANKFRAME_OPENED()
+            end
+        end
         BankFrame.selectedTab = 2
         BankFrame.activeTabIndex = 2
     end


### PR DESCRIPTION
## Summary
- Refresh warband bank containers when switching to its tab so items load immediately

## Testing
- `luacheck .` *(fails: command not found)*
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68969f6b3160832e83d3d62207049bd2