### PR TITLE
Update DJBags for WoW 11.2 API changes

### DIFF
--- a/DJBags.toc
+++ b/DJBags.toc
@@ -1,8 +1,8 @@
-## Interface: 90002
+## Interface: 110200
 ## Title: DJBags
 ## Author: DarkJaguar91
 ## Notes: BagAddon
-## Version: 9.0.1
+## Version: 11.2.0
 ## SavedVariables: DJBags_DB
 ## SavedVariablesPerCharacter: DJBags_DB_Char
 

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -10,7 +10,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 1, ContainerIDToInventoryID(1))
+                        DJBagsBagItemLoad(self, 1, C_Container.ContainerIDToInventoryID(1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -20,7 +20,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 2, ContainerIDToInventoryID(2))
+                        DJBagsBagItemLoad(self, 2, C_Container.ContainerIDToInventoryID(2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -30,7 +30,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 3, ContainerIDToInventoryID(3))
+                        DJBagsBagItemLoad(self, 3, C_Container.ContainerIDToInventoryID(3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -40,7 +40,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, 4, ContainerIDToInventoryID(4))
+                        DJBagsBagItemLoad(self, 4, C_Container.ContainerIDToInventoryID(4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -36,7 +36,7 @@ function item:Update()
         return
     end
     PaperDollItemSlotButton_Update(self)
-    local slotcount = GetContainerNumSlots(self.slot)
+    local slotcount = C_Container.GetContainerNumSlots(self.slot)
     if slotcount > 0 then
         self.Count:SetText(tostring(slotcount))
         self.Count:Show()

--- a/src/base/BaseBag.lua
+++ b/src/base/BaseBag.lua
@@ -66,7 +66,7 @@ end
 local function GetAllItems(self, bags)
     local updateOccured = false
     for _, bag in pairs(bags) do
-        local bagSlots = GetContainerNumSlots(bag)
+        local bagSlots = C_Container.GetContainerNumSlots(bag)
         local container = self.containers[bag]
         for slot = 1, bagSlots do
             if not container.items[slot] then

--- a/src/category/CategoryManager.lua
+++ b/src/category/CategoryManager.lua
@@ -17,7 +17,7 @@ function categoryManager:GetTitle(item, filters)
     local slot = item:GetID()
 
     if item.id then
-        local isInSet, setName = GetContainerItemEquipmentSetInfo(bag, slot)
+        local isInSet, setName = C_Container.GetContainerItemEquipmentSetInfo(bag, slot)
 
         if item.quality == Enum.ItemQuality.Poor then
             return BAG_FILTER_JUNK

--- a/src/category/PlayerDefined.lua
+++ b/src/category/PlayerDefined.lua
@@ -1,7 +1,8 @@
 local ADDON_NAME, ADDON = ...
 
 DJBags_AddCategoryFilter(function(bag, slot)
-    local _, _, _, _, _, _, _, _, _, id = GetContainerItemInfo(bag, slot)
+    local info = C_Container.GetContainerItemInfo(bag, slot)
+    local id = info and info.itemID
 
     return DJBags_DB_Char.categories[id] or DJBags_DB.categories[id]
 end, 'Player defined categories')


### PR DESCRIPTION
## Summary
- Update interface version for patch 11.2
- Switch deprecated container API calls to C_Container equivalents

## Testing
- `luac -p src/base/BaseBag.lua src/bagItem/BagItem.lua src/category/PlayerDefined.lua src/category/CategoryManager.lua src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_68994f5b839c832ea51627ef11177527