### PR TITLE
Add fallback for missing BankButtonIDToInvSlotID

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -1,5 +1,17 @@
 local ADDON_NAME, ADDON = ...
 
+if not BankButtonIDToInvSlotID then
+	if C_Container and C_Container.ContainerIDToInventoryID then
+		function BankButtonIDToInvSlotID(buttonID)
+			return C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
+		end
+	elseif ContainerIDToInventoryID then
+		function BankButtonIDToInvSlotID(buttonID)
+			return ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
+		end
+	end
+end
+
 -- Formatter types
 ADDON.formats = {
 	MASONRY = 0,


### PR DESCRIPTION
## Summary
- add compatibility shim for `BankButtonIDToInvSlotID` when missing to prevent bank bag errors

## Testing
- `luacheck src`


------
https://chatgpt.com/codex/tasks/task_e_6899515cbe48832e88f89d623be1042d