### PR TITLE
Fix bank tab resize error by initializing Text reference

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -155,6 +155,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
+                        self.Text = self:GetFontString();
                         PanelTemplates_TabResize(self, 0);
                         self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
                         self.tab = 1
@@ -170,6 +171,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
+                        self.Text = self:GetFontString();
                         PanelTemplates_TabResize(self, 0);
                         self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
                         self.tab = 2


### PR DESCRIPTION
## Summary
- initialize TabButtonText references for bank tabs before resizing to avoid nil errors

## Testing
- `luac -p $(find src -name '*.lua')`


------
https://chatgpt.com/codex/tasks/task_e_689953841724832e85d7274837c05403