### PR TITLE
Fix bank tab template to avoid nil Left error

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -149,7 +149,7 @@
                     <Anchor point="RIGHT" relativeTo="$parentDepositReagent" relativePoint="LEFT" x="-5" />
                 </Anchors>
             </EditBox>
-            <Button name="$parentTab1" inherits="TabButtonTemplate" text="BANK">
+            <Button name="$parentTab1" inherits="PanelTabButtonTemplate" text="BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parent" relativePoint="TOPLEFT" />
                 </Anchors>
@@ -165,7 +165,7 @@
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentTab2" inherits="TabButtonTemplate" text="REAGENT_BANK">
+            <Button name="$parentTab2" inherits="PanelTabButtonTemplate" text="REAGENT_BANK">
                 <Anchors>
                     <Anchor point="BOTTOMLEFT" relativeTo="$parentTab1" relativePoint="BOTTOMRIGHT" />
                 </Anchors>


### PR DESCRIPTION
## Summary
- use PanelTabButtonTemplate for bank tabs to provide expected textures

## Testing
- `luacheck .` *(fails: command not found)*
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_689954a93768832ea057648aa0451762