### PR TITLE
Fix bank tab highlight initialization error

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -157,7 +157,10 @@
                     <OnLoad>
                         self.Text = self:GetFontString();
                         PanelTemplates_TabResize(self, 0);
-                        self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        local highlight = self:GetHighlightTexture();
+                        if highlight then
+                            highlight:SetWidth(self:GetTextWidth() + 31);
+                        end
                         self.tab = 1
                     </OnLoad>
                     <OnClick>
@@ -173,7 +176,10 @@
                     <OnLoad>
                         self.Text = self:GetFontString();
                         PanelTemplates_TabResize(self, 0);
-                        self.HighlightTexture:SetWidth(self:GetTextWidth() + 31);
+                        local highlight = self:GetHighlightTexture();
+                        if highlight then
+                            highlight:SetWidth(self:GetTextWidth() + 31);
+                        end
                         self.tab = 2
                     </OnLoad>
                     <OnClick>


### PR DESCRIPTION
## Summary
- Avoid nil errors by retrieving bank tab highlight textures with `GetHighlightTexture`

## Testing
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_689955ba30c4832e876c5362b3ae1726