### PR TITLE
Fix Backdrop usage for modern WoW versions

### DIFF
--- a/src/category/Category.xml
+++ b/src/category/Category.xml
@@ -19,7 +19,7 @@
             </Layer>
         </Layers>
         <Frames>
-            <EditBox name="$parentCategoryEdit" parentKey="edit">
+            <EditBox name="$parentCategoryEdit" parentKey="edit" inherits="BackdropTemplate">
                 <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
                     <EdgeSize>
                         <AbsValue val="1" />

--- a/src/settings/CategorySettings.xml
+++ b/src/settings/CategorySettings.xml
@@ -1,7 +1,7 @@
 <Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/  http://wowprogramming.com/FrameXML/UI.xsd">
     <Script file="src/settings/CategorySettings.lua"/>
 
-    <Frame name="DJBagsCategorySettings" virtual="true" movable="true" enableMouse="true">
+    <Frame name="DJBagsCategorySettings" virtual="true" movable="true" enableMouse="true" inherits="BackdropTemplate">
         <Size x="100" y="100" />
         <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>

--- a/src/settings/Settings.xml
+++ b/src/settings/Settings.xml
@@ -2,7 +2,7 @@
 	<Script file="src/settings/Settings.lua"/>
     <Include file="src/settings/CategorySettings.xml"/>
 
-	<Frame name="DJBagsNumberSelectTemplate" virtual="true">
+    <Frame name="DJBagsNumberSelectTemplate" virtual="true" inherits="BackdropTemplate">
 		<Size y="29" />
 		<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>
@@ -66,7 +66,7 @@
 			</Button>
 		</Frames>
 	</Frame>
-    <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate" virtual="true" movable="true" enableMouse="true">
+    <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate, BackdropTemplate" virtual="true" movable="true" enableMouse="true">
     	<Size x="150" y="105" />
     	<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>


### PR DESCRIPTION
## Summary
- add BackdropTemplate to category edit box to prevent "Unrecognized XML: Backdrop" errors
- ensure settings frames inherit BackdropTemplate so their backdrops render correctly

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET, re
files=['src/category/Category.xml','src/settings/CategorySettings.xml','src/settings/Settings.xml']
for f in files:
    text=re.sub(r'\s*xsi:schemaLocation="[^"]*"','',open(f).read())
    ET.fromstring(text)
    print(f,'OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689957372114832eb50914366d679204