### PR TITLE
Replace BackdropInfo with Backdrop tags in settings XML

### DIFF
--- a/src/settings/CategorySettings.xml
+++ b/src/settings/CategorySettings.xml
@@ -3,11 +3,11 @@
 
     <Frame name="DJBagsCategorySettings" virtual="true" movable="true" enableMouse="true" inherits="BackdropTemplate">
         <Size x="100" y="100" />
-        <BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
+        <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>
                 <AbsValue val="1" />
             </EdgeSize>
-        </BackdropInfo>
+        </Backdrop>
         <BackdropColor r="0" g="0" b="0" a="0.6" />
         <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1" />
         <Layers>

--- a/src/settings/Settings.xml
+++ b/src/settings/Settings.xml
@@ -4,11 +4,11 @@
 
     <Frame name="DJBagsNumberSelectTemplate" virtual="true" inherits="BackdropTemplate">
 		<Size y="29" />
-		<BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
+		<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>
                 <AbsValue val="1" />
             </EdgeSize>
-        </BackdropInfo>
+        </Backdrop>
         <BackdropColor r="0" g="0" b="0" a="0" />
         <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1" />
 		<Layers>
@@ -68,11 +68,11 @@
 	</Frame>
     <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate, BackdropTemplate" virtual="true" movable="true" enableMouse="true">
     	<Size x="150" y="105" />
-    	<BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
+    	<Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
             <EdgeSize>
                 <AbsValue val="1" />
             </EdgeSize>
-        </BackdropInfo>
+        </Backdrop>
         <BackdropColor r="0" g="0" b="0" a="0.6" />
         <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1" />
         <Frames>


### PR DESCRIPTION
## Summary
- fix unrecognized `BackdropInfo` tags by switching to `Backdrop`
- update settings XMLs to match current WoW UI schema

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
for f in ['src/settings/Settings.xml', 'src/settings/CategorySettings.xml']:
    content = open(f).read().replace('xsi:', '')
    ET.fromstring(content)
    print(f'Parsed {f} after removing xsi prefix')
PY`
- `apt-get install -y libxml2-utils` *(fails: Unable to locate package)*
- `luac -p src/settings/Settings.lua src/settings/CategorySettings.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995bde66cc832ead03cf54d9b37e52