### PR TITLE
Fix Backdrop XML usage in settings

### DIFF
--- a/src/settings/CategorySettings.xml
+++ b/src/settings/CategorySettings.xml
@@ -3,13 +3,13 @@
 
     <Frame name="DJBagsCategorySettings" virtual="true" movable="true" enableMouse="true" inherits="BackdropTemplate">
         <Size x="100" y="100" />
-        <Backdrop>
-            <BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-                <EdgeSize val="1"/>
-            </BackdropInfo>
-            <BackdropColor r="0" g="0" b="0" a="0.6"/>
-            <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1"/>
-        </Backdrop>
+        <Scripts>
+            <OnLoad>
+                self:SetBackdrop({bgFile = "Interface\ChatFrame\ChatFrameBackground", edgeFile = "Interface\Buttons\WHITE8x8", edgeSize = 1})
+                self:SetBackdropColor(0, 0, 0, 0.6)
+                self:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+            </OnLoad>
+        </Scripts>
         <Layers>
             <Layer level="OVERLAY">
                 <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight">

--- a/src/settings/Settings.xml
+++ b/src/settings/Settings.xml
@@ -4,13 +4,13 @@
 
     <Frame name="DJBagsNumberSelectTemplate" virtual="true" inherits="BackdropTemplate">
 		<Size y="29" />
-		<Backdrop>
-            <BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-                <EdgeSize val="1"/>
-            </BackdropInfo>
-            <BackdropColor r="0" g="0" b="0" a="0"/>
-            <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1"/>
-        </Backdrop>
+                <Scripts>
+            <OnLoad>
+                self:SetBackdrop({bgFile = "Interface\ChatFrame\ChatFrameBackground", edgeFile = "Interface\Buttons\WHITE8x8", edgeSize = 1})
+                self:SetBackdropColor(0, 0, 0, 0)
+                self:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+            </OnLoad>
+        </Scripts>
 		<Layers>
             <Layer level="OVERLAY">
                 <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight">
@@ -68,13 +68,13 @@
 	</Frame>
     <Frame name="DJBagsSettings" inherits="DJBagsBackgroundTemplate, BackdropTemplate" virtual="true" movable="true" enableMouse="true">
     	<Size x="150" y="105" />
-    	<Backdrop>
-            <BackdropInfo bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\Buttons\WHITE8x8">
-                <EdgeSize val="1"/>
-            </BackdropInfo>
-            <BackdropColor r="0" g="0" b="0" a="0.6"/>
-            <BackdropBorderColor r="0.3" g="0.3" b="0.3" a="1"/>
-        </Backdrop>
+        <Scripts>
+            <OnLoad>
+                self:SetBackdrop({bgFile = "Interface\ChatFrame\ChatFrameBackground", edgeFile = "Interface\Buttons\WHITE8x8", edgeSize = 1})
+                self:SetBackdropColor(0, 0, 0, 0.6)
+                self:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+            </OnLoad>
+        </Scripts>
         <Frames>
         	<Frame name="$parentColumnsSettings" parentKey="columns" inherits="DJBagsNumberSelectTemplate">
         		<Anchors>


### PR DESCRIPTION
## Summary
- remove deprecated `<Backdrop>` blocks from settings XML files
- apply backdrops at runtime using `SetBackdrop` and color setup

## Testing
- `luac -p src/settings/Settings.lua src/settings/CategorySettings.lua`


------
https://chatgpt.com/codex/tasks/task_e_68995f7ebc90832e883f5a8643f4cb02