### PR TITLE
Fix XML attribute typo in bag frame

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -244,7 +244,7 @@
         </Scripts>
     </Frame>
 
-    <Frame name="DJBagsBag2" inhertis="DJBagsBackgroundTemplate" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
+    <Frame name="DJBagsBag2" inherits="DJBagsBackgroundTemplate" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
            hidden="true" parent="UIParent">
         <Size x="100" y="100" />
         <Anchors>


### PR DESCRIPTION
## Summary
- correct misspelled `inhertis` attribute in `Bag.xml`

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `find src -name '*.lua' -print | xargs -I{} luac -p {}` *(fails: luac: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689960fa248c832e9c71ed24813cfcfa