### PR TITLE
fix: avoid calling removed IsBattlePayItem

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -218,7 +218,12 @@ function item:Update()
     else
         local isQuestItem, questId, isActive = C_Container.GetContainerItemQuestInfo(bag, slot)
         local isNewItem = C_NewItems.IsNewItem(bag, self:GetID())
-        local isBattlePayItem = IsBattlePayItem(bag, self:GetID())
+        local isBattlePayItem = false
+        if C_Item and C_Item.IsBattlePayItem then
+            isBattlePayItem = C_Item.IsBattlePayItem(bag, self:GetID())
+        elseif IsBattlePayItem then
+            isBattlePayItem = IsBattlePayItem(bag, self:GetID())
+        end
 
         self.hasItem = true
 


### PR DESCRIPTION
## Summary
- guard IsBattlePayItem usage and use C_Item.IsBattlePayItem when available

## Testing
- `luac -p src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_689961d97814832e91bb04904ad03f55