### PR TITLE
Guard bag upgrade check for missing API

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -153,7 +153,12 @@ end
 
 local function UpdateUpgrade(self)
     self.timeSinceUpgradeCheck = 0;
-    
+    if not C_Container or not C_Container.IsContainerItemAnUpgrade then
+        self.UpgradeIcon:SetShown(false);
+        self:SetScript("OnUpdate", nil);
+        return;
+    end
+
     local itemIsUpgrade = C_Container.IsContainerItemAnUpgrade(self:GetParent():GetID(), self:GetID());
     if ( itemIsUpgrade == nil ) then -- nil means not all the data was available to determine if this is an upgrade.
         self.UpgradeIcon:SetShown(false);


### PR DESCRIPTION
## Summary
- Avoid calling `C_Container.IsContainerItemAnUpgrade` when the API is missing
- Default to hiding the upgrade icon when upgrade data isn't available

## Testing
- `luac -p src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_68996446c3e8832ea55c5324b76a8564