### PR TITLE
fix: guard equipable check for empty bag slots

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -192,7 +192,8 @@ function item:Update()
         filtered = info.isFiltered
         id = info.itemID
     end
-    local equipable = IsEquippableItem(id)
+    -- prevent errors on empty slots where id is nil
+    local equipable = id and IsEquippableItem(id)
 
     local name, level, classId, class, subClass
     if id then


### PR DESCRIPTION
## Summary
- avoid `IsEquippableItem` errors by ensuring bag slot has item ID before calling

## Testing
- `luac -p src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_68996633a9e4832eae6c2f8ce0e50592