### PR TITLE
Handle removed CloseBankFrame API

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -317,7 +317,11 @@
                 DJBagsRegisterBankFrame(self)
             </OnLoad>
             <OnHide>
-                CloseBankFrame()
+                if CloseBankFrame then
+                    CloseBankFrame()
+                elseif CloseBank then
+                    CloseBank()
+                end
                 StaticPopup_Hide("CONFIRM_BUY_BANK_SLOT")
             </OnHide>
         </Scripts>


### PR DESCRIPTION
## Summary
- safely close the bank frame by checking for `CloseBankFrame` or `CloseBank` before calling

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('src/bank/Bank.xml')
print('XML parsed OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a8915c9ec832eb8c11828a36deae8