### PR TITLE
Fix item border color to reflect item rarity

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -244,13 +244,11 @@ function item:Update()
         UpdateUpgrade(self)
         self:UpdateItemContextMatching()
 
-        if MSQ then
-            if quality and quality >= Enum.ItemQuality.Common and BAG_ITEM_QUALITY_COLORS[quality] then
-                self.IconBorder:Show();
-                self.IconBorder:SetVertexColor(BAG_ITEM_QUALITY_COLORS[quality].r, BAG_ITEM_QUALITY_COLORS[quality].g, BAG_ITEM_QUALITY_COLORS[quality].b);
-            else
-                self.IconBorder:Hide();
-            end
+        if quality and quality >= Enum.ItemQuality.Common and BAG_ITEM_QUALITY_COLORS[quality] then
+            self.IconBorder:Show()
+            self.IconBorder:SetVertexColor(BAG_ITEM_QUALITY_COLORS[quality].r, BAG_ITEM_QUALITY_COLORS[quality].g, BAG_ITEM_QUALITY_COLORS[quality].b)
+        else
+            self.IconBorder:Hide()
         end
     end
 end


### PR DESCRIPTION
## Summary
- ensure item borders use quality colors instead of always showing gold

## Testing
- `luac -p src/item/Item.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d597fe0832eb9410d265c25bd22