### PR TITLE
Use item quality for icon borders

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -243,18 +243,9 @@ function item:Update()
         UpdateUpgrade(self)
         self:UpdateItemContextMatching()
 
-        local r, g, b
+        SetItemButtonQuality(self, quality, id)
         if isQuestItem or questId then
-            r, g, b = 1, 0.82, 0
-        elseif quality and BAG_ITEM_QUALITY_COLORS[quality] then
-            r, g, b = BAG_ITEM_QUALITY_COLORS[quality].r, BAG_ITEM_QUALITY_COLORS[quality].g, BAG_ITEM_QUALITY_COLORS[quality].b
-        end
-
-        if r then
-            self.IconBorder:Show()
-            self.IconBorder:SetVertexColor(r, g, b)
-        else
-            self.IconBorder:Hide()
+            self.IconBorder:SetVertexColor(1, 0.82, 0)
         end
     end
 end


### PR DESCRIPTION
## Summary
- use `SetItemButtonQuality` to color borders by item rarity
- leave quest items with their gold border

## Testing
- `luac -p item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a90b7c464832e8245468348f46f91