### PR TITLE
Respect item quality for icon border colors

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -122,6 +122,25 @@ local function UpdateFiltered(self, filtered)
     end
 end
 
+local function UpdateBorder(self, quality, isQuestItem, questId)
+    if isQuestItem or questId then
+        self.IconBorder:SetVertexColor(1, 0.82, 0)
+        self.IconBorder:Show()
+        return
+    end
+
+    if quality and quality > Enum.ItemQuality.Common then
+        local color = BAG_ITEM_QUALITY_COLORS[quality]
+        if color then
+            self.IconBorder:SetVertexColor(color.r, color.g, color.b)
+            self.IconBorder:Show()
+            return
+        end
+    end
+
+    self.IconBorder:Hide()
+end
+
 local function UpdateILevel(self, equipable, quality, level)
     if equipable then
         if quality and quality >= Enum.ItemQuality.Common then
@@ -243,10 +262,7 @@ function item:Update()
         UpdateUpgrade(self)
         self:UpdateItemContextMatching()
 
-        SetItemButtonQuality(self, quality, id)
-        if isQuestItem or questId then
-            self.IconBorder:SetVertexColor(1, 0.82, 0)
-        end
+        UpdateBorder(self, quality, isQuestItem, questId)
     end
 end
 


### PR DESCRIPTION
## Summary
- Tint item icon borders using the correct quality color
- Hide borders for low-quality items and keep quest items gold

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_689a91dd11ec832ea39b67ce12c3b8f7