### PR TITLE
Fix icon border color based on item rarity

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -242,7 +242,7 @@ function item:Update()
     if bag == BANK_CONTAINER or bag == REAGENTBANK_CONTAINER then
         BankFrameItemButton_Update(self)
     else
-        local isQuestItem, questId, isActive = C_Container.GetContainerItemQuestInfo(bag, slot)
+        local questId, isQuestItem, isActive = C_Container.GetContainerItemQuestInfo(bag, slot)
         local isNewItem = C_NewItems.IsNewItem(bag, self:GetID())
         local isBattlePayItem = false
         if C_Item and C_Item.IsBattlePayItem then


### PR DESCRIPTION
## Summary
- Adjust quest info return order to stop all bag items from displaying quest borders.

## Testing
- `luac -p src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_689aa7d18180832eb4bdffd41be0b939