### PR TITLE
Hide Blizzard bank when opening DJBags bank

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -17,6 +17,10 @@ function DJBagsRegisterBankBagContainer(self, bags)
 
     BankFrame:UnregisterAllEvents()
     BankFrame:SetScript('OnShow', nil)
+    BankFrame:HookScript('OnShow', BankFrame.Hide)
+    if BankFrame:IsShown() then
+        BankFrame:Hide()
+    end
 end
 
 function bank:BANKFRAME_OPENED()

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -200,6 +200,14 @@
             <OnLoad>
                 DJBagsRegisterBankFrame(self)
             </OnLoad>
+            <OnShow>
+                if OpenBankFrame and not BankFrame:IsShown() then
+                    OpenBankFrame()
+                end
+                if BankFrame:IsShown() then
+                    BankFrame:Hide()
+                end
+            </OnShow>
             <OnHide>
                 if CloseBankFrame then
                     CloseBankFrame()


### PR DESCRIPTION
## Summary
- Ensure the default Blizzard BankFrame stays hidden when interacting with bankers
- Open and close bank API calls when DJBags bank frame is shown/hidden

## Testing
- `luac -p src/bank/Bank.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ab1461da0832e86d7c6990357d820