### PR TITLE
Hide Blizzard bank when opening DJBags bank

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -3,8 +3,16 @@ local ADDON_NAME, ADDON = ...
 local bank = {}
 bank.__index = bank
 
+function DJBagsHideBlizzardBank()
+    BankFrame:SetAlpha(0)
+    BankFrame:EnableMouse(false)
+    BankFrame:SetScale(0.0001)
+    BankFrame:ClearAllPoints()
+    BankFrame:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', -9999, -9999)
+end
+
 function DJBagsRegisterBankBagContainer(self, bags)
-	DJBagsRegisterBaseBagContainer(self, bags)
+    DJBagsRegisterBaseBagContainer(self, bags)
 
 	for k, v in pairs(bank) do
 		self[k] = v
@@ -16,7 +24,8 @@ function DJBagsRegisterBankBagContainer(self, bags)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
 
     BankFrame:UnregisterAllEvents()
-    BankFrame:SetScript('OnShow', nil)
+    BankFrame:SetScript('OnShow', DJBagsHideBlizzardBank)
+    DJBagsHideBlizzardBank()
 end
 
 function bank:BANKFRAME_OPENED()

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -200,6 +200,14 @@
             <OnLoad>
                 DJBagsRegisterBankFrame(self)
             </OnLoad>
+            <OnShow>
+                if OpenBankFrame and not BankFrame:IsShown() then
+                    OpenBankFrame()
+                end
+                if BankFrame:IsShown() then
+                    DJBagsHideBlizzardBank()
+                end
+            </OnShow>
             <OnHide>
                 if CloseBankFrame then
                     CloseBankFrame()


### PR DESCRIPTION
## Summary
- Keep Blizzard BankFrame open but invisible so right-click item transfers continue to work
- Call DJBagsHideBlizzardBank instead of hiding BankFrame outright when opening the DJBags bank

## Testing
- `luac -p src/bank/Bank.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ab1461da0832e86d7c6990357d820