### PR TITLE
Fix bank bar slots and icons

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -1,15 +1,16 @@
 local ADDON_NAME, ADDON = ...
 
 if not BankButtonIDToInvSlotID then
-	if C_Container and C_Container.ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	elseif ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	end
+        local bagOffset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+        if C_Container and C_Container.ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID)
+                        return C_Container.ContainerIDToInventoryID(bagOffset + buttonID)
+                end
+        elseif ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID)
+                        return ContainerIDToInventoryID(bagOffset + buttonID)
+                end
+        end
 end
 
 -- Formatter types

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -49,6 +49,18 @@ function item:Update()
         return
     end
     PaperDollItemSlotButton_Update(self)
+
+    if (self.icon or self.Icon) and not (self.icon or self.Icon):GetTexture() then
+        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+        if C_Bank and C_Bank.GetBankTabInfo and self.slot > offset then
+            local tabInfo = C_Bank.GetBankTabInfo(self.slot - offset)
+            local icon = tabInfo and (tabInfo.iconFileID or tabInfo.iconTexture)
+            if icon then
+                SetItemButtonTexture(self, icon)
+            end
+        end
+    end
+
     local slotcount = C_Container.GetContainerNumSlots(self.slot)
     if slotcount > 0 then
         self.Count:SetText(tostring(slotcount))

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -14,17 +14,19 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 1, BankButtonIDToInvSlotID(1))
                     </OnLoad>
                 </Scripts>
-            </ItemButton>
+                </ItemButton>
             <ItemButton name="$parentBag2" parentKey="bag2">
                 <Anchors>
                     <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 2, BankButtonIDToInvSlotID(2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -34,7 +36,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 3, BankButtonIDToInvSlotID(3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -44,7 +47,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 4, BankButtonIDToInvSlotID(4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -54,7 +58,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 5, BankButtonIDToInvSlotID(5))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -64,7 +69,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 6, BankButtonIDToInvSlotID(6))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -74,7 +80,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 7, BankButtonIDToInvSlotID(7))
                     </OnLoad>
                 </Scripts>
             </ItemButton>


### PR DESCRIPTION
## Summary
- account for reagent bag when mapping bank slots
- show bank tab icons when not set by PaperDollItemSlotButton_Update
- skip reagent bag in bank bar slot calculations

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf3fc718832ea32de2bee7ffd947