### PR TITLE
Fix bank bar slots and icons

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -1,15 +1,22 @@
 local ADDON_NAME, ADDON = ...
 
 if not BankButtonIDToInvSlotID then
-	if C_Container and C_Container.ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	elseif ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	end
+        local reagentSlots = rawget(_G, "NUM_REAGENTBAG_SLOTS")
+        if reagentSlots == nil then
+                -- Modern clients always have a reagent bag slot even if unused
+                reagentSlots = 1
+        end
+
+        local bagOffset = (NUM_BAG_SLOTS or 0) + reagentSlots
+        if C_Container and C_Container.ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID)
+                        return C_Container.ContainerIDToInventoryID(bagOffset + buttonID)
+                end
+        elseif ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID)
+                        return ContainerIDToInventoryID(bagOffset + buttonID)
+                end
+        end
 end
 
 -- Formatter types

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -14,14 +14,20 @@ function item:Init(id, slot)
     self:SetID(id)
     self.slot = slot
 
+    -- Allow both left and right clicks as well as dragging with the left button
+    self:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+    self:RegisterForDrag("LeftButton")
+
     self:SetScript('OnDragStart', self.DragItem)
     self:SetScript('OnReceiveDrag', self.PlaceOrPickup)
-    self:SetScript('OnClick', function (self, ...)
+    self:SetScript('OnClick', function (self, button, ...)
         if self.buy then
             PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
             StaticPopup_Show("CONFIRM_BUY_BANK_SLOT")
+        elseif button == "RightButton" and BankItemButtonBag_OnClick then
+            BankItemButtonBag_OnClick(self, button, ...)
         else
-            self:PlaceOrPickup(...)
+            self:PlaceOrPickup(button, ...)
         end
     end)
     self:SetScript('OnEnter', self.OnEnter)
@@ -49,6 +55,16 @@ function item:Update()
         return
     end
     PaperDollItemSlotButton_Update(self)
+
+    local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+    if C_Bank and C_Bank.GetBankTabInfo and self.slot > offset then
+        local tabInfo = C_Bank.GetBankTabInfo(self.slot - offset)
+        local icon = tabInfo and (tabInfo.iconFileID or tabInfo.iconTexture or tabInfo.icon)
+        if icon then
+            SetItemButtonTexture(self, icon)
+        end
+    end
+
     local slotcount = C_Container.GetContainerNumSlots(self.slot)
     if slotcount > 0 then
         self.Count:SetText(tostring(slotcount))

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -14,17 +14,19 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 1, BankButtonIDToInvSlotID(1))
                     </OnLoad>
                 </Scripts>
-            </ItemButton>
+                </ItemButton>
             <ItemButton name="$parentBag2" parentKey="bag2">
                 <Anchors>
                     <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="TOPRIGHT" x="5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 2, BankButtonIDToInvSlotID(2))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -34,7 +36,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 3, BankButtonIDToInvSlotID(3))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -44,7 +47,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 4, BankButtonIDToInvSlotID(4))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -54,7 +58,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 5, BankButtonIDToInvSlotID(5))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -64,7 +69,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 6, BankButtonIDToInvSlotID(6))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -74,7 +80,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
+                        local offset = (NUM_BAG_SLOTS or 0) + (NUM_REAGENTBAG_SLOTS or 0)
+                        DJBagsBagItemLoad(self, offset + 7, BankButtonIDToInvSlotID(7))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -140,7 +147,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsRegisterBankBagContainer(self, {BANK_CONTAINER, 5, 6, 7, 8, 9, 10, 11})
+                        DJBagsRegisterBankBagContainer(self, {BANK_CONTAINER, 6, 7, 8, 9, 10, 11, 12})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()


### PR DESCRIPTION
## Summary
- register bag tab buttons for right click and drag
- keep bank tab icons when PaperDoll update clears them
- always offset bank slot IDs to skip reagent bag
- remove reagent bag from bank container registration

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf3fc718832ea32de2bee7ffd947