### PR TITLE
Include reagent bag in inventory only

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -2,14 +2,14 @@ local ADDON_NAME, ADDON = ...
 
 if not BankButtonIDToInvSlotID then
 	if C_Container and C_Container.ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return C_Container.ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	elseif ContainerIDToInventoryID then
-		function BankButtonIDToInvSlotID(buttonID)
-			return ContainerIDToInventoryID(NUM_BAG_SLOTS + buttonID)
-		end
-	end
+                function BankButtonIDToInvSlotID(buttonID)
+                        return C_Container.ContainerIDToInventoryID(NUM_TOTAL_EQUIPPED_BAG_SLOTS + buttonID)
+                end
+        elseif ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID)
+                        return ContainerIDToInventoryID(NUM_TOTAL_EQUIPPED_BAG_SLOTS + buttonID)
+                end
+        end
 end
 
 -- Formatter types

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -2,7 +2,7 @@
     <Script file="src/bag/bag.lua"/>
 
     <Frame name="DJBagsBagBarTemplate" inherits="DJBagsBackgroundTemplate" virtual="true" movable="true" enableMouse="true">
-        <Size x="183" y="58" />
+        <Size x="230" y="58" />
         <Frames>
             <ItemButton name="$parentBag1" parentKey="bag1">
                 <Anchors>
@@ -41,6 +41,16 @@
                 <Scripts>
                     <OnLoad>
                         DJBagsBagItemLoad(self, 4, C_Container.ContainerIDToInventoryID(4))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag5" parentKey="bag5">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, 5, C_Container.ContainerIDToInventoryID(5))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -233,7 +243,7 @@
         </Frames>
         <Scripts>
             <OnLoad>
-                DJBagsRegisterBagBagContainer(self, {0, 1, 2, 3, 4})
+                DJBagsRegisterBagBagContainer(self, {0, 1, 2, 3, 4, 5})
             </OnLoad>
             <OnShow>
                 self:OnShow()

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -38,7 +38,7 @@ function item:Update()
         numBankSlots, full = 0, true
     end
 
-    if self.slot - NUM_BAG_SLOTS > numBankSlots then
+    if self.slot - NUM_TOTAL_EQUIPPED_BAG_SLOTS > numBankSlots then
         local cost = -1
         if type(GetBankSlotCost) == "function" then
             cost = GetBankSlotCost(self.slot - 1)

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -14,7 +14,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -24,7 +24,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -34,7 +34,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -44,7 +44,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -54,7 +54,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -64,7 +64,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -74,7 +74,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
+                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -140,7 +140,14 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsRegisterBankBagContainer(self, {BANK_CONTAINER, 5, 6, 7, 8, 9, 10, 11})
+                        DJBagsRegisterBankBagContainer(self, {BANK_CONTAINER,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 1,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 2,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 3,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 4,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 5,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 6,
+                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 7})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()

--- a/src/category/CategoryManager.lua
+++ b/src/category/CategoryManager.lua
@@ -27,7 +27,7 @@ function categoryManager:GetTitle(item, filters)
             return setName
         end
 
-        if bag >= 0 and bag <= NUM_BAG_SLOTS and (C_NewItems.IsNewItem(bag, slot) or DJBags_DB_Char.newItems[item.id]) then
+        if bag >= 0 and bag <= NUM_TOTAL_EQUIPPED_BAG_SLOTS and (C_NewItems.IsNewItem(bag, slot) or DJBags_DB_Char.newItems[item.id]) then
           DJBags_DB_Char.newItems[item.id] = true
           return NEW
         end


### PR DESCRIPTION
## Summary
- show the reagent bag in the character inventory
- exclude the reagent bag from the bank view
- account for reagent bag when tracking new items

## Testing
- `luacheck .` *(fails: command not found)*
- `luac -p src/Constants.lua src/bagItem/BagItem.lua src/category/CategoryManager.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be9a68500832e86c1197079d9e474