### PR TITLE
Handle missing bank bag frames safely

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -44,10 +44,13 @@ end
 
 function bank:BAG_UPDATE_DELAYED()
     for _, bag in pairs(self.bags) do
-    	if bag ~= BANK_CONTAINER then
-			DJBagsBankBar['bag' .. bag - NUM_BAG_SLOTS]:Update()
-		end
-	end
+        if bag ~= BANK_CONTAINER then
+            local barItem = DJBagsBankBar['bag' .. (bag - NUM_TOTAL_EQUIPPED_BAG_SLOTS)]
+            if barItem then
+                barItem:Update()
+            end
+        end
+    end
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()


### PR DESCRIPTION
## Summary
- fix bank bag update to use NUM_TOTAL_EQUIPPED_BAG_SLOTS offset
- guard bank bag update with nil check

## Testing
- `luacheck src/bank/Bank.lua`

------
https://chatgpt.com/codex/tasks/task_e_689beb91144c832e858aaeda8defced2