### PR TITLE
fix: hide warband items in character bank

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -29,9 +29,12 @@ function DJBagsRegisterBankBagContainer(self, bags)
 end
 
 function bank:BANKFRAME_OPENED()
-	if (BankFrame.selectedTab or 1) == 1 then
-		self:Show()
-	end
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    if not bankType or bankType == Enum.BankType.Character then
+        self:Show()
+    else
+        self:Hide()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -20,13 +20,29 @@ function DJBagsRegisterBankFrame(self, bags)
         self:StopMovingOrSizing(...)
     end)
     self:SetUserPlaced(true)
+
+    -- Update our visibility when the bank switches between character and account tabs.
+    hooksecurefunc(BankFrame, "SetTab", function()
+        self:UpdateBankType()
+    end)
+end
+
+function bankFrame:UpdateBankType()
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    if not bankType or bankType == Enum.BankType.Character then
+        self.bankBag:Show()
+        self:Show()
+    else
+        self.bankBag:Hide()
+        self:Hide()
+    end
 end
 
 function bankFrame:BANKFRAME_OPENED()
-        self:Show()
+    self:UpdateBankType()
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
-	self:Hide()
+    self:Hide()
 end


### PR DESCRIPTION
## Summary
- show DJBags bank UI unless warband/account bank tab is active
- only hide bank contents when the warband tab is selected

## Testing
- `npm test` (fails: Could not read package.json)
- `luac -p src/bank/BankFrame.lua src/bank/Bank.lua` (fails: command not found: luac)


------
https://chatgpt.com/codex/tasks/task_e_689bee10b30c832eaba14392066c268b