### PR TITLE
fix: hide warband items in character bank

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -14,9 +14,16 @@ end
 function DJBagsRegisterBankBagContainer(self, bags)
     DJBagsRegisterBaseBagContainer(self, bags)
 
-	for k, v in pairs(bank) do
-		self[k] = v
-	end
+    -- Save the original BAG_UPDATE implementation so we can gate updates
+    -- while the warband bank is active.
+    self.baseBAG_UPDATE = self.BAG_UPDATE
+
+    for k, v in pairs(bank) do
+        self[k] = v
+    end
+
+    -- Default to the character bank being active until told otherwise.
+    self.isCharacterBank = true
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
@@ -29,20 +36,35 @@ function DJBagsRegisterBankBagContainer(self, bags)
 end
 
 function bank:BANKFRAME_OPENED()
-	if (BankFrame.selectedTab or 1) == 1 then
-		self:Show()
-	end
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    self.isCharacterBank = not bankType or bankType == Enum.BankType.Character
+    if self.isCharacterBank then
+        self:Show()
+    else
+        self:Hide()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()
 	self:Hide()
 end
 
+function bank:BAG_UPDATE(bag)
+    if self.isCharacterBank then
+        self:baseBAG_UPDATE(bag)
+    end
+end
+
 function bank:PLAYERBANKSLOTS_CHANGED()
-	self:BAG_UPDATE(BANK_CONTAINER)
+    if self.isCharacterBank then
+        self:BAG_UPDATE(BANK_CONTAINER)
+    end
 end
 
 function bank:BAG_UPDATE_DELAYED()
+    if not self.isCharacterBank then
+        return
+    end
     for _, bag in pairs(self.bags) do
         if bag ~= BANK_CONTAINER then
             local barItem = DJBagsBankBar['bag' .. (bag - NUM_TOTAL_EQUIPPED_BAG_SLOTS)]
@@ -54,5 +76,7 @@ function bank:BAG_UPDATE_DELAYED()
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()
-	self:BAG_UPDATE_DELAYED()
+    if self.isCharacterBank then
+        self:BAG_UPDATE_DELAYED()
+    end
 end

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -20,13 +20,32 @@ function DJBagsRegisterBankFrame(self, bags)
         self:StopMovingOrSizing(...)
     end)
     self:SetUserPlaced(true)
+
+    -- Update our visibility when the bank switches between character and account tabs.
+    hooksecurefunc(BankFrame, "SetTab", function()
+        self:UpdateBankType()
+    end)
+end
+
+function bankFrame:UpdateBankType()
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    local isCharacterBank = not bankType or bankType == Enum.BankType.Character
+    self.bankBag.isCharacterBank = isCharacterBank
+
+    if isCharacterBank then
+        self.bankBag:Show()
+        self:Show()
+    else
+        self.bankBag:Hide()
+        self:Hide()
+    end
 end
 
 function bankFrame:BANKFRAME_OPENED()
-        self:Show()
+    self:UpdateBankType()
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
-	self:Hide()
+    self:Hide()
 end

--- a/src/base/BaseBag.lua
+++ b/src/base/BaseBag.lua
@@ -82,6 +82,16 @@ local function GetAllItems(self, bags)
                 updateOccured = true
             end
         end
+
+        -- Hide leftover slots when the bag shrinks (e.g., switching
+        -- from the larger account bank to the smaller character bank).
+        for slot = bagSlots + 1, #container.items do
+            local item = container.items[slot]
+            if item then
+                item.id = nil
+                item:Hide()
+            end
+        end
     end
     if updateOccured then
         self:Format()


### PR DESCRIPTION
## Summary
- ignore warband bank updates by tracking active bank type
- toggle bank visibility based on selected bank tab
- hide leftover slots when switching from the larger account bank to the character bank

## Testing
- `npm test` (fails: Could not read package.json)
- `luac -p src/bank/BankFrame.lua src/bank/Bank.lua src/base/BaseBag.lua`


------
https://chatgpt.com/codex/tasks/task_e_689bee10b30c832eaba14392066c268b