### PR TITLE
fix: hide warband items in character bank

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -1,13 +1,22 @@
 local ADDON_NAME, ADDON = ...
 
 if not BankButtonIDToInvSlotID then
-	if C_Container and C_Container.ContainerIDToInventoryID then
-                function BankButtonIDToInvSlotID(buttonID)
-                        return C_Container.ContainerIDToInventoryID(NUM_TOTAL_EQUIPPED_BAG_SLOTS + buttonID)
+        local function GetContainerID(buttonID, bankType)
+                bankType = bankType or Enum.BankType.Character
+                if bankType == Enum.BankType.Account then
+                        return Enum.BagIndex.AccountBankTab_1 + buttonID - 1
+                else
+                        return Enum.BagIndex.CharacterBankTab_1 + buttonID - 1
+                end
+        end
+
+        if C_Container and C_Container.ContainerIDToInventoryID then
+                function BankButtonIDToInvSlotID(buttonID, bankType)
+                        return C_Container.ContainerIDToInventoryID(GetContainerID(buttonID, bankType))
                 end
         elseif ContainerIDToInventoryID then
-                function BankButtonIDToInvSlotID(buttonID)
-                        return ContainerIDToInventoryID(NUM_TOTAL_EQUIPPED_BAG_SLOTS + buttonID)
+                function BankButtonIDToInvSlotID(buttonID, bankType)
+                        return ContainerIDToInventoryID(GetContainerID(buttonID, bankType))
                 end
         end
 end

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -14,9 +14,16 @@ end
 function DJBagsRegisterBankBagContainer(self, bags)
     DJBagsRegisterBaseBagContainer(self, bags)
 
-	for k, v in pairs(bank) do
-		self[k] = v
-	end
+    -- Save the original BAG_UPDATE implementation so we can gate updates
+    -- while the warband bank is active.
+    self.baseBAG_UPDATE = self.BAG_UPDATE
+
+    for k, v in pairs(bank) do
+        self[k] = v
+    end
+
+    -- Default to the character bank being active until told otherwise.
+    self.isCharacterBank = true
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
@@ -29,30 +36,46 @@ function DJBagsRegisterBankBagContainer(self, bags)
 end
 
 function bank:BANKFRAME_OPENED()
-	if (BankFrame.selectedTab or 1) == 1 then
-		self:Show()
-	end
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    self.isCharacterBank = not bankType or bankType == Enum.BankType.Character
+    if self.isCharacterBank then
+        self:Show()
+    else
+        self:Hide()
+    end
 end
 
 function bank:BANKFRAME_CLOSED()
 	self:Hide()
 end
 
+function bank:BAG_UPDATE(bag)
+    if self.isCharacterBank then
+        self:baseBAG_UPDATE(bag)
+    end
+end
+
 function bank:PLAYERBANKSLOTS_CHANGED()
-	self:BAG_UPDATE(BANK_CONTAINER)
+    if self.isCharacterBank then
+        self:BAG_UPDATE_DELAYED()
+    end
 end
 
 function bank:BAG_UPDATE_DELAYED()
+    if not self.isCharacterBank then
+        return
+    end
     for _, bag in pairs(self.bags) do
-        if bag ~= BANK_CONTAINER then
-            local barItem = DJBagsBankBar['bag' .. (bag - NUM_TOTAL_EQUIPPED_BAG_SLOTS)]
-            if barItem then
-                barItem:Update()
-            end
+        local barIndex = bag - Enum.BagIndex.CharacterBankTab_1 + 1
+        local barItem = DJBagsBankBar['bag' .. barIndex]
+        if barItem then
+            barItem:Update()
         end
     end
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()
-	self:BAG_UPDATE_DELAYED()
+    if self.isCharacterBank then
+        self:BAG_UPDATE_DELAYED()
+    end
 end

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -14,7 +14,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 1, BankButtonIDToInvSlotID(1, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_1, BankButtonIDToInvSlotID(1, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -24,7 +24,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 2, BankButtonIDToInvSlotID(2, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_2, BankButtonIDToInvSlotID(2, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -34,7 +34,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 3, BankButtonIDToInvSlotID(3, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_3, BankButtonIDToInvSlotID(3, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -44,7 +44,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 4, BankButtonIDToInvSlotID(4, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_4, BankButtonIDToInvSlotID(4, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -54,7 +54,7 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 5, BankButtonIDToInvSlotID(5, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_5, BankButtonIDToInvSlotID(5, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
@@ -64,24 +64,14 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 6, BankButtonIDToInvSlotID(6, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag7" parentKey="bag7">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag6" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, NUM_TOTAL_EQUIPPED_BAG_SLOTS + 7, BankButtonIDToInvSlotID(7, 1))
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_6, BankButtonIDToInvSlotID(6, 1))
                     </OnLoad>
                 </Scripts>
             </ItemButton>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag7" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" relativeTo="$parentBag6" relativePoint="BOTTOMRIGHT" y="-9.5" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -140,14 +130,13 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        DJBagsRegisterBankBagContainer(self, {BANK_CONTAINER,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 1,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 2,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 3,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 4,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 5,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 6,
-                                NUM_TOTAL_EQUIPPED_BAG_SLOTS + 7})
+                        DJBagsRegisterBankBagContainer(self, {
+                                Enum.BagIndex.CharacterBankTab_1,
+                                Enum.BagIndex.CharacterBankTab_2,
+                                Enum.BagIndex.CharacterBankTab_3,
+                                Enum.BagIndex.CharacterBankTab_4,
+                                Enum.BagIndex.CharacterBankTab_5,
+                                Enum.BagIndex.CharacterBankTab_6})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -20,13 +20,32 @@ function DJBagsRegisterBankFrame(self, bags)
         self:StopMovingOrSizing(...)
     end)
     self:SetUserPlaced(true)
+
+    -- Update our visibility when the bank switches between character and account tabs.
+    hooksecurefunc(BankFrame, "SetTab", function()
+        self:UpdateBankType()
+    end)
+end
+
+function bankFrame:UpdateBankType()
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    local isCharacterBank = not bankType or bankType == Enum.BankType.Character
+    self.bankBag.isCharacterBank = isCharacterBank
+
+    if isCharacterBank then
+        self.bankBag:Show()
+        self:Show()
+    else
+        self.bankBag:Hide()
+        self:Hide()
+    end
 end
 
 function bankFrame:BANKFRAME_OPENED()
-        self:Show()
+    self:UpdateBankType()
     DJBagsBag:Show()
 end
 
 function bankFrame:BANKFRAME_CLOSED()
-	self:Hide()
+    self:Hide()
 end

--- a/src/base/BaseBag.lua
+++ b/src/base/BaseBag.lua
@@ -82,6 +82,16 @@ local function GetAllItems(self, bags)
                 updateOccured = true
             end
         end
+
+        -- Hide leftover slots when the bag shrinks (e.g., switching
+        -- from the larger account bank to the smaller character bank).
+        for slot = bagSlots + 1, #container.items do
+            local item = container.items[slot]
+            if item then
+                item.id = nil
+                item:Hide()
+            end
+        end
     end
     if updateOccured then
         self:Format()

--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -50,9 +50,9 @@ function ADDON:NewItem(parent, slot)
 	assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
 	assert(slot and type(slot) == 'number', 'Slot required as integer value')
 
-        local object = CreateFrame('ItemButton', string.format('DJBagsItem_%d_%d', bag, slot), parent,
-                bag == BANK_CONTAINER and 'BankItemButtonGenericTemplate' or
-            'ContainerFrameItemButtonTemplate')
+        local isBankItem = bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_6
+        local template = isBankItem and 'BankItemButtonGenericTemplate' or 'ContainerFrameItemButtonTemplate'
+        local object = CreateFrame('ItemButton', string.format('DJBagsItem_%d_%d', bag, slot), parent, template)
 
 	for k, v in pairs(item) do
 		object[k] = v
@@ -259,7 +259,7 @@ function item:Update()
     end
 
     UpdateILevel(self, equipable, quality, level)
-    if bag == BANK_CONTAINER then
+    if bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_6 then
         BankFrameItemButton_Update(self)
     else
         -- GetContainerItemQuestInfo changed in Dragonflight to return a table.


### PR DESCRIPTION
## Summary
- switch bank bag setup to CharacterBankTab enums so only character bank tabs are tracked
- index bank tab updates relative to the first character bank tab
- add enum-aware fallback for `BankButtonIDToInvSlotID`
- treat character bank tab items as bank items during creation and update

## Testing
- `npm test` (fails: Could not read package.json)
- `luac -p src/bank/Bank.lua src/bank/BankFrame.lua src/base/BaseBag.lua src/Constants.lua src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_689bee10b30c832eaba14392066c268b