### PR TITLE
Handle missing bank item template gracefully

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -51,8 +51,19 @@ function ADDON:NewItem(parent, slot)
 	assert(slot and type(slot) == 'number', 'Slot required as integer value')
 
         local isBankItem = bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_6
-        local template = isBankItem and 'BankItemButtonGenericTemplate' or 'ContainerFrameItemButtonTemplate'
-        local object = CreateFrame('ItemButton', string.format('DJBagsItem_%d_%d', bag, slot), parent, template)
+        local frameName = string.format('DJBagsItem_%d_%d', bag, slot)
+        local object
+
+        if isBankItem then
+                local ok, frame = pcall(CreateFrame, 'ItemButton', frameName, parent, 'BankItemButtonGenericTemplate')
+                if ok then
+                        object = frame
+                else
+                        object = CreateFrame('ItemButton', frameName, parent, 'ContainerFrameItemButtonTemplate')
+                end
+        else
+                object = CreateFrame('ItemButton', frameName, parent, 'ContainerFrameItemButtonTemplate')
+        end
 
 	for k, v in pairs(item) do
 		object[k] = v


### PR DESCRIPTION
## Summary
- add fallback when `BankItemButtonGenericTemplate` is unavailable

## Testing
- `luac -p src/item/Item.lua`


------
https://chatgpt.com/codex/tasks/task_e_689bfa9addd8832e8b121c1dcd1bb62f