### PR TITLE
Fix right-click menu for bank tabs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -24,11 +24,11 @@ function item:Init(id, slot)
         end
 
         -- Right-clicking a bank tab should open the default bank tab settings menu
-        if button == "RightButton" and BankFrame and BankFrame.BankPanel and BankFrame.BankPanel.TabSettingsMenu then
+        if button == "RightButton" and BankFrame and BankFrame.BankPanel and BankFrame.BankPanel.OpenTabSettingsMenu then
             local slot = self.slot
             local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
             if isCharacterBankTab then
-                BankFrame.BankPanel.TabSettingsMenu:TriggerEvent(BankPanelTabSettingsMenuMixin.Event.OpenTabSettingsRequested, slot)
+                BankFrame.BankPanel:OpenTabSettingsMenu(slot)
                 return
             end
         end


### PR DESCRIPTION
## Summary
- use `BankPanel:OpenTabSettingsMenu` to open default settings when right-clicking bank tabs

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c01faac8c832eb82194f5e4440a9d