### PR TITLE
Fix bank tab right-click context menu

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -28,7 +28,8 @@ function item:Init(id, slot)
             local slot = self.slot
             local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
             if isCharacterBankTab then
-                BankFrame.BankPanel:OpenTabSettingsMenu(slot)
+                local tabIndex = slot - Enum.BagIndex.CharacterBankTab_1 + 1
+                BankFrame.BankPanel:OpenTabSettingsMenu(tabIndex, self)
                 return
             end
         end


### PR DESCRIPTION
## Summary
- Ensure bank tab right-click opens the default tab settings menu by mapping to the correct tab index and anchoring the menu to the clicked button.

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c038ed420832ea13c8d3cbbeeb21d