### PR TITLE
Fix bank tab right-click options

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -24,12 +24,12 @@ function item:Init(id, slot)
         end
 
         -- Right-clicking a bank tab should open the default bank tab settings menu
-        if button == "RightButton" and BankFrame and BankFrame.BankPanel and BankFrame.BankPanel.OpenTabSettingsMenu then
+        if button == "RightButton" and BankFrame and BankFrame.BankPanel and BankFrame.BankPanel.TabSettingsMenu and BankPanelTabSettingsMenuMixin then
             local slot = self.slot
             local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
             if isCharacterBankTab then
-                local tabIndex = slot - Enum.BagIndex.CharacterBankTab_1 + 1
-                BankFrame.BankPanel:OpenTabSettingsMenu(tabIndex, self)
+                BankFrame.BankPanel.TabSettingsMenu:TriggerEvent(BankPanelTabSettingsMenuMixin.Event.OpenTabSettingsRequested, slot)
+                PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
                 return
             end
         end


### PR DESCRIPTION
## Summary
- Ensure bank tab right-click uses Blizzard's TabSettingsMenu event to show default options

## Testing
- `luac -p src/bagItem/BagItem.lua`
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_689c04f16984832e8c28ab10fb339452