### PR TITLE
Fix bank tab settings menu anchor for right click

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -41,7 +41,7 @@ function item:Init(id, slot)
             end
 
             if isBankTab then
-                BankFrame.BankPanel.TabSettingsMenu:TriggerEvent(BankPanelTabSettingsMenuMixin.Event.OpenTabSettingsRequested, slot)
+                BankFrame.BankPanel.TabSettingsMenu:TriggerEvent(BankPanelTabSettingsMenuMixin.Event.OpenTabSettingsRequested, slot, self)
                 PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
                 return
             end


### PR DESCRIPTION
## Summary
- ensure bank tab context menu anchors to the clicked DJBags tab

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c08f4305c832e984dca01b9788ef6