### PR TITLE
Enable right-click tab settings for bank tabs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -14,6 +14,9 @@ function item:Init(id, slot)
     self:SetID(id)
     self.slot = slot
 
+    -- Allow both left and right button clicks so we can open bank tab settings
+    self:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+
     self:SetScript('OnDragStart', self.DragItem)
     self:SetScript('OnReceiveDrag', self.PlaceOrPickup)
     self:SetScript('OnClick', function (self, button, ...)


### PR DESCRIPTION
## Summary
- Allow bag bar items to register right-clicks
- Open default bank tab settings menu when right-clicking bank tabs

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c0a52e9a8832e9036ab8770d34282