### PR TITLE
Use Blizzard bank tabs

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -62,16 +62,7 @@ function bank:PLAYERBANKSLOTS_CHANGED()
 end
 
 function bank:BAG_UPDATE_DELAYED()
-    if not self.isCharacterBank then
-        return
-    end
-    for _, bag in pairs(self.bags) do
-        local barIndex = bag - Enum.BagIndex.CharacterBankTab_1 + 1
-        local barItem = DJBagsBankBar['bag' .. barIndex]
-        if barItem then
-            barItem:Update()
-        end
-    end
+    -- No bank bar items to update; the default Blizzard tab bar handles its own updates.
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -8,70 +8,10 @@
             <Anchor point="TOPLEFT" x="150" y="-100" />
         </Anchors>
         <Frames>
-            <ItemButton name="$parentBag1" parentKey="bag1">
-                <Anchors>
-                    <Anchor point="TOPLEFT" x="9" y="-9" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_1, BankButtonIDToInvSlotID(1, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag2" parentKey="bag2">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_2, BankButtonIDToInvSlotID(2, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag3" parentKey="bag3">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag2" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_3, BankButtonIDToInvSlotID(3, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag4" parentKey="bag4">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag3" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_4, BankButtonIDToInvSlotID(4, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag5" parentKey="bag5">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_5, BankButtonIDToInvSlotID(5, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag6" parentKey="bag6">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag5" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_6, BankButtonIDToInvSlotID(6, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag6" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" x="-9" y="-9" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -93,7 +33,7 @@
             <Button name="$parentSettingsBtn">
                 <Size x="16" y="16"/>
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="BOTTOMLEFT" x="0" y="-5"/>
+                    <Anchor point="TOPLEFT" x="9" y="-9"/>
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled"/>
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up"/>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -25,6 +25,27 @@ function DJBagsRegisterBankFrame(self, bags)
     hooksecurefunc(BankFrame, "SetTab", function()
         self:UpdateBankType()
     end)
+
+    self:AttachTabBar()
+end
+
+function bankFrame:AttachTabBar()
+    if self.tabBar then
+        return
+    end
+
+    local tabBar = BankFrame.BankPanel and BankFrame.BankPanel.TabBar
+    if not tabBar then
+        return
+    end
+
+    tabBar:SetParent(self)
+    tabBar:ClearAllPoints()
+    tabBar:SetPoint("TOPLEFT", self, "TOPRIGHT", 0, -20)
+    tabBar:SetScale(1)
+    tabBar:SetAlpha(1)
+    tabBar:Show()
+    self.tabBar = tabBar
 end
 
 function bankFrame:UpdateBankType()
@@ -42,6 +63,7 @@ function bankFrame:UpdateBankType()
 end
 
 function bankFrame:BANKFRAME_OPENED()
+    self:AttachTabBar()
     self:UpdateBankType()
     DJBagsBag:Show()
 end


### PR DESCRIPTION
## Summary
- remove custom bank bag buttons and re-anchor header controls
- reuse Blizzard's bank tab bar on the custom bank frame
- drop manual bank bar update logic
- ensure the tab bar attaches to the custom frame when opened

## Testing
- `luacheck src/bank/Bank.lua src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_689faab69c88832e8136511116be2f26