### PR TITLE
Expand bank tab support

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -6,11 +6,11 @@ local OPEN_TAB_SETTINGS_EVENT = BankPanelTabSettingsMenuMixin and BankPanelTabSe
 local BANK_TAB_CLICKED_EVENT = BankPanelMixin and BankPanelMixin.Event.BankTabClicked or "BankTabClicked"
 
 local function isBankTabSlot(slot)
-    if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6 then
+    if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
         return true
     end
-    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_6 then
-        if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_6 then
+    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_8 then
+        if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_8 then
             return true
         end
     end
@@ -64,7 +64,7 @@ end
 
 function item:Update()
     local slot = self.slot
-    local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
+    local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
 
     if C_Bank and isCharacterBankTab then
         -- Determine if this tab has been purchased

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -3,7 +3,7 @@
     <Script file="src/bank/Bank.lua"/>
 
     <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" movable="true" enableMouse="true" hidden="true">
-        <Size x="307" y="85" />
+        <Size x="407" y="85" />
         <Anchors>
             <Anchor point="TOPLEFT" x="150" y="-100" />
         </Anchors>
@@ -68,10 +68,30 @@
                     </OnLoad>
                 </Scripts>
             </ItemButton>
+            <ItemButton name="$parentBag7" parentKey="bag7">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag6" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_7, BankButtonIDToInvSlotID(7, 1))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag8" parentKey="bag8">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag7" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_8, BankButtonIDToInvSlotID(8, 1))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag6" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" relativeTo="$parentBag8" relativePoint="BOTTOMRIGHT" y="-9.5" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -136,7 +156,9 @@
                                 Enum.BagIndex.CharacterBankTab_3,
                                 Enum.BagIndex.CharacterBankTab_4,
                                 Enum.BagIndex.CharacterBankTab_5,
-                                Enum.BagIndex.CharacterBankTab_6})
+                                Enum.BagIndex.CharacterBankTab_6,
+                                Enum.BagIndex.CharacterBankTab_7,
+                                Enum.BagIndex.CharacterBankTab_8})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()

--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -50,7 +50,7 @@ function ADDON:NewItem(parent, slot)
 	assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
 	assert(slot and type(slot) == 'number', 'Slot required as integer value')
 
-        local isBankItem = bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_6
+        local isBankItem = bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8
         local frameName = string.format('DJBagsItem_%d_%d', bag, slot)
         local object
 
@@ -270,7 +270,7 @@ function item:Update()
     end
 
     UpdateILevel(self, equipable, quality, level)
-    if bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_6 then
+    if bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8 then
         if BankFrameItemButton_Update then
             BankFrameItemButton_Update(self)
         end


### PR DESCRIPTION
## Summary
- show all eight bank tabs in the DJBags bank bar
- treat new tab slots as bank tabs for icon and settings menu support
- recognize bank items in the expanded tab range

## Testing
- `luac -p src/item/Item.lua src/bagItem/BagItem.lua`
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_689fafd08404832e9f64bd9fe890d4f9