### PR TITLE
Guard bank tab detection when enums missing

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -2,11 +2,13 @@ local ADDON_NAME, ADDON = ...
 
 if not BankButtonIDToInvSlotID then
         local function GetContainerID(buttonID, bankType)
-                bankType = bankType or Enum.BankType.Character
-                if bankType == Enum.BankType.Account then
+                bankType = bankType or (Enum.BankType and Enum.BankType.Character)
+                if bankType == (Enum.BankType and Enum.BankType.Account) and Enum.BagIndex.AccountBankTab_1 then
                         return Enum.BagIndex.AccountBankTab_1 + buttonID - 1
-                else
+                elseif Enum.BagIndex.CharacterBankTab_1 then
                         return Enum.BagIndex.CharacterBankTab_1 + buttonID - 1
+                else
+                        return 4 + buttonID
                 end
         end
 

--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -6,13 +6,11 @@ local OPEN_TAB_SETTINGS_EVENT = BankPanelTabSettingsMenuMixin and BankPanelTabSe
 local BANK_TAB_CLICKED_EVENT = BankPanelMixin and BankPanelMixin.Event.BankTabClicked or "BankTabClicked"
 
 local function isBankTabSlot(slot)
-    if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 and slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
         return true
     end
-    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_8 then
-        if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_8 then
-            return true
-        end
+    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_8 and slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_8 then
+        return true
     end
     return false
 end
@@ -64,7 +62,7 @@ end
 
 function item:Update()
     local slot = self.slot
-    local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
+    local isCharacterBankTab = Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 and slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
 
     if C_Bank and isCharacterBankTab then
         -- Determine if this tab has been purchased

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -66,7 +66,7 @@ function bank:BAG_UPDATE_DELAYED()
         return
     end
     for _, bag in pairs(self.bags) do
-        local barIndex = bag - Enum.BagIndex.CharacterBankTab_1 + 1
+        local barIndex = Enum.BagIndex.CharacterBankTab_1 and (bag - Enum.BagIndex.CharacterBankTab_1 + 1) or bag
         local barItem = DJBagsBankBar['bag' .. barIndex]
         if barItem then
             barItem:Update()

--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -47,10 +47,10 @@ end
 
 function ADDON:NewItem(parent, slot)
     local bag = parent:GetID()
-	assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
-	assert(slot and type(slot) == 'number', 'Slot required as integer value')
+        assert(bag and type(bag) == 'number', 'Parent is required to be a bag with ID set the bag number')
+        assert(slot and type(slot) == 'number', 'Slot required as integer value')
 
-        local isBankItem = bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8
+        local isBankItem = Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 and bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8
         local frameName = string.format('DJBagsItem_%d_%d', bag, slot)
         local object
 
@@ -270,7 +270,7 @@ function item:Update()
     end
 
     UpdateILevel(self, equipable, quality, level)
-    if bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8 then
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 and bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8 then
         if BankFrameItemButton_Update then
             BankFrameItemButton_Update(self)
         end


### PR DESCRIPTION
## Summary
- handle missing `Enum.BagIndex.CharacterBankTab_*` values
- avoid errors when the bank tab enums are unavailable

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb1846f30832eb175b6d402e935be