### PR TITLE
Guard bank tab enum usage against nil

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -274,7 +274,12 @@ function item:Update()
     end
 
     UpdateILevel(self, equipable, quality, level)
-    if bag >= Enum.BagIndex.CharacterBankTab_1 and bag <= Enum.BagIndex.CharacterBankTab_8 then
+
+    -- Character bank tab enums were introduced in later game versions.  Guard
+    -- against them being nil on older clients before comparing bag indices.
+    local bankTabStart = Enum.BagIndex and Enum.BagIndex.CharacterBankTab_1
+    local bankTabEnd = Enum.BagIndex and Enum.BagIndex.CharacterBankTab_8
+    if bankTabStart and bankTabEnd and bag >= bankTabStart and bag <= bankTabEnd then
         if BankFrameItemButton_Update then
             BankFrameItemButton_Update(self)
         end


### PR DESCRIPTION
## Summary
- Avoid comparing bag indices to nil when bank tab enums are unavailable

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_689fb4556008832e9ec7c4a4660c45c7