### PR TITLE
Handle missing bank tab enums

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -6,8 +6,10 @@ local OPEN_TAB_SETTINGS_EVENT = BankPanelTabSettingsMenuMixin and BankPanelTabSe
 local BANK_TAB_CLICKED_EVENT = BankPanelMixin and BankPanelMixin.Event.BankTabClicked or "BankTabClicked"
 
 local function isBankTabSlot(slot)
-    if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
-        return true
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 then
+        if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
+            return true
+        end
     end
     if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_8 then
         if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_8 then
@@ -64,7 +66,10 @@ end
 
 function item:Update()
     local slot = self.slot
-    local isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
+    local isCharacterBankTab = false
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 then
+        isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
+    end
 
     if C_Bank and isCharacterBankTab then
         -- Determine if this tab has been purchased


### PR DESCRIPTION
## Summary
- avoid nil comparisons when checking bank tab slots
- safely detect character bank tabs before fetching bank data

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_689fb62428e4832e8d05d568e1bf04db