### PR TITLE
Handle nil bank tab slots safely

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -70,6 +70,13 @@ end
 
 function item:Update()
     local slot = self.slot
+    if not slot then
+        PaperDollItemSlotButton_Update(self)
+        self.Count:Hide()
+        self.buy = nil
+        return
+    end
+
     local isCharacterBankTab = false
     if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 then
         isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8


### PR DESCRIPTION
## Summary
- Skip container slot lookups when a bag item has no associated slot to avoid GetContainerNumSlots errors

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb91c9634832eb5e5e14fc084ee6d