### PR TITLE
Limit bank to six tabs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -6,13 +6,13 @@ local OPEN_TAB_SETTINGS_EVENT = BankPanelTabSettingsMenuMixin and BankPanelTabSe
 local BANK_TAB_CLICKED_EVENT = BankPanelMixin and BankPanelMixin.Event.BankTabClicked or "BankTabClicked"
 
 local function isBankTabSlot(slot)
-    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 then
-        if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8 then
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_6 then
+        if slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6 then
             return true
         end
     end
-    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_8 then
-        if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_8 then
+    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_6 then
+        if slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_6 then
             return true
         end
     end
@@ -78,8 +78,8 @@ function item:Update()
     end
 
     local isCharacterBankTab = false
-    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_8 then
-        isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_8
+    if Enum.BagIndex.CharacterBankTab_1 and Enum.BagIndex.CharacterBankTab_6 then
+        isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
     end
 
     if C_Bank and isCharacterBankTab then

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -65,7 +65,7 @@ function bank:BAG_UPDATE_DELAYED()
     if not self.isCharacterBank then
         return
     end
-    for i = 1, 8 do
+    for i = 1, 6 do
         local barItem = DJBagsBankBar['bag' .. i]
         if barItem then
             barItem:Update()
@@ -73,7 +73,7 @@ function bank:BAG_UPDATE_DELAYED()
     end
 
     local prev
-    for i = 1, 8 do
+    for i = 1, 6 do
         local barItem = DJBagsBankBar['bag' .. i]
         if barItem and barItem:IsShown() then
             barItem:ClearAllPoints()

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -3,7 +3,7 @@
     <Script file="src/bank/Bank.lua"/>
 
     <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" movable="true" enableMouse="true" hidden="true">
-        <Size x="407" y="85" />
+        <Size x="323" y="85" />
         <Anchors>
             <Anchor point="TOPLEFT" x="150" y="-100" />
         </Anchors>
@@ -68,30 +68,10 @@
                     </OnLoad>
                 </Scripts>
             </ItemButton>
-            <ItemButton name="$parentBag7" parentKey="bag7">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag6" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_7, BankButtonIDToInvSlotID(7, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
-            <ItemButton name="$parentBag8" parentKey="bag8">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag7" relativePoint="TOPRIGHT" x="5" />
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        DJBagsBagItemLoad(self, Enum.BagIndex.CharacterBankTab_8, BankButtonIDToInvSlotID(8, 1))
-                    </OnLoad>
-                </Scripts>
-            </ItemButton>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag8" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" relativeTo="$parentBag6" relativePoint="BOTTOMRIGHT" y="-9.5" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -156,9 +136,7 @@
                                 Enum.BagIndex.CharacterBankTab_3,
                                 Enum.BagIndex.CharacterBankTab_4,
                                 Enum.BagIndex.CharacterBankTab_5,
-                                Enum.BagIndex.CharacterBankTab_6,
-                                Enum.BagIndex.CharacterBankTab_7,
-                                Enum.BagIndex.CharacterBankTab_8})
+                                Enum.BagIndex.CharacterBankTab_6})
                     </OnLoad>
                     <OnShow>
                         self:OnShow()

--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -53,7 +53,7 @@ function ADDON:NewItem(parent, slot)
         local numBags = NUM_BAG_SLOTS or 4
         local numBankBags = NUM_BANKBAGSLOTS or 7
         local firstBankBag = Enum.BagIndex.CharacterBankTab_1 or Enum.BagIndex.BankBag_1 or (numBags + 1)
-        local lastBankBag = Enum.BagIndex.CharacterBankTab_8 or Enum.BagIndex.BankBag_7 or (numBags + numBankBags)
+        local lastBankBag = Enum.BagIndex.CharacterBankTab_6 or Enum.BagIndex.BankBag_6 or (numBags + numBankBags)
         local isBankItem = bag >= firstBankBag and bag <= lastBankBag
         local frameName = string.format('DJBagsItem_%d_%d', bag, slot)
         local object
@@ -278,7 +278,7 @@ function item:Update()
     -- Character bank tab enums were introduced in later game versions.  Guard
     -- against them being nil on older clients before comparing bag indices.
     local bankTabStart = Enum.BagIndex and Enum.BagIndex.CharacterBankTab_1
-    local bankTabEnd = Enum.BagIndex and Enum.BagIndex.CharacterBankTab_8
+    local bankTabEnd = Enum.BagIndex and Enum.BagIndex.CharacterBankTab_6
     if bankTabStart and bankTabEnd and bag >= bankTabStart and bag <= bankTabEnd then
         if BankFrameItemButton_Update then
             BankFrameItemButton_Update(self)


### PR DESCRIPTION
## Summary
- show only six bank tab buttons and resize bank bar
- update bank logic and item helpers to use six tabs

## Testing
- `luac -p src/bank/Bank.lua`
- `luac -p src/bagItem/BagItem.lua`
- `luac -p src/item/Item.lua`
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3adc6570832e9b5b519fd83e5888