### PR TITLE
Fix bag sorting API in Dragonflight

### DIFF
--- a/src/bag/Bag.lua
+++ b/src/bag/Bag.lua
@@ -13,9 +13,13 @@ function DJBagsRegisterBagBagContainer(self, bags)
     ADDON.eventManager:Add("NewItemCleared", self)
 end
 
-function bag:SortBags()    
+function bag:SortBags()
     ADDON.eventManager:Remove('BAG_UPDATE', self)
-    SortBags()
+    if C_Container and C_Container.SortBags then
+        C_Container.SortBags()
+    elseif SortBags then
+        SortBags()
+    end
     ADDON.eventManager:Add('BAG_UPDATE', self)
 end
 

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -86,7 +86,11 @@
                         GameTooltip:Hide()
                     </OnLeave>
                     <OnClick>
-                        SortBankBags()
+                        if C_Container and C_Container.SortBankBags then
+                            C_Container.SortBankBags()
+                        elseif SortBankBags then
+                            SortBankBags()
+                        end
                     </OnClick>
                 </Scripts>
             </Button>


### PR DESCRIPTION
## Summary
- use C_Container.SortBags when available to sort inventory
- update bank restack button to use new C_Container.SortBankBags API

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n 1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68ad3d2c938c832ebdfc0f9c97b6f665