### PR TITLE
Increase bank column limit to 30

### DIFF
--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -5,9 +5,9 @@ function DJBagsSettingsColumnsLoad(self)
 		self.name:SetText(ADDON.locale.COLUMNS:format(self:GetParent().bag.settings.maxColumns))
 	end
 	self.up.process = function() 
-		local currentCount = self:GetParent().bag.settings.maxColumns
-		if (currentCount < 20) then
-			self:GetParent().bag.settings.maxColumns = currentCount + 1
+                local currentCount = self:GetParent().bag.settings.maxColumns
+                if (currentCount < 30) then
+                        self:GetParent().bag.settings.maxColumns = currentCount + 1
 
 			self:Update()
 			self:GetParent().bag:Refresh()


### PR DESCRIPTION
## Summary
- allow up to 30 columns in settings panel

## Testing
- `luac -p src/settings/Settings.lua`


------
https://chatgpt.com/codex/tasks/task_e_68adf09d2c44832e87ab307ffa791ff1