### PR TITLE
Fix bank tab settings menu not loading selected tab

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -58,16 +58,39 @@ function item:Init(id, slot)
             menu:ClearAllPoints()
             menu:SetPoint("TOPLEFT", BankFrame, "TOPRIGHT")
             menu:Show()
+
+            -- Trigger the tab settings menu to load details for the correct bank tab.
+            -- Some client builds expect the request via the global EventRegistry
+            -- rather than the menu frame itself, so attempt both for compatibility.
             if bankType then
-                menu:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, bankType, tabIndex)
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, bankType, tabIndex)
+                else
+                    menu:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, bankType, tabIndex)
+                end
             else
-                menu:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, tabIndex)
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, tabIndex)
+                else
+                    menu:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, tabIndex)
+                end
             end
+
             PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
+
+            -- Notify the bank panel which tab was selected so the menu becomes interactive.
             if bankType then
-                BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
+                else
+                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
+                end
             else
-                BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
+                else
+                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
+                end
             end
             return
         end


### PR DESCRIPTION
## Summary
- Ensure bank tab settings menu requests are routed through EventRegistry when available
- Fallback to legacy frame events for older clients so right-clicking a bank tab remains functional

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68adfa157b3c832eb3fdaa1497cc684f