### PR TITLE
Fix bank tab settings menu initialization order

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -59,9 +59,26 @@ function item:Init(id, slot)
             menu:SetPoint("TOPLEFT", BankFrame, "TOPRIGHT")
             menu:Show()
 
-            -- Trigger the tab settings menu to load details for the correct bank tab.
-            -- Some client builds expect the request via the global EventRegistry
-            -- rather than the menu frame itself, so attempt both for compatibility.
+            -- Notify the bank panel which tab was selected so the menu becomes
+            -- interactive before requesting the menu details.
+            if bankType then
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
+                else
+                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
+                end
+            else
+                if EventRegistry and EventRegistry.TriggerEvent then
+                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
+                else
+                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
+                end
+            end
+
+            -- Trigger the tab settings menu to load details for the correct
+            -- bank tab.  Some client builds expect the request via the global
+            -- EventRegistry rather than the menu frame itself, so attempt both
+            -- for compatibility.
             if bankType then
                 if EventRegistry and EventRegistry.TriggerEvent then
                     EventRegistry:TriggerEvent(OPEN_TAB_SETTINGS_EVENT, bankType, tabIndex)
@@ -77,21 +94,6 @@ function item:Init(id, slot)
             end
 
             PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
-
-            -- Notify the bank panel which tab was selected so the menu becomes interactive.
-            if bankType then
-                if EventRegistry and EventRegistry.TriggerEvent then
-                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
-                else
-                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, bankType, tabIndex)
-                end
-            else
-                if EventRegistry and EventRegistry.TriggerEvent then
-                    EventRegistry:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
-                else
-                    BankFrame.BankPanel:TriggerEvent(BANK_TAB_CLICKED_EVENT, tabIndex)
-                end
-            end
             return
         end
 


### PR DESCRIPTION
## Summary
- ensure bank tab settings menu receives tab selection before loading content

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ae59ce1858832e88fb2d189e3d2ba6