### PR TITLE
Handle account bank type for tab settings menu

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -45,8 +45,18 @@ function item:Init(id, slot)
 
         -- Right-clicking a bank tab should open the default bank tab settings menu
         if button == "RightButton" and BankFrame and BankFrame.BankPanel and BankFrame.BankPanel.TabSettingsMenu and isBankTabSlot(self.slot) then
-            local tabIndex = self.slot - Enum.BagIndex.CharacterBankTab_1 + 1
-            local bankType = Enum.BankType and Enum.BankType.Character
+            local tabIndex, bankType
+
+            if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_6
+                and self.slot >= Enum.BagIndex.AccountBankTab_1
+                and self.slot <= Enum.BagIndex.AccountBankTab_6
+            then
+                tabIndex = self.slot - Enum.BagIndex.AccountBankTab_1 + 1
+                bankType = Enum.BankType and Enum.BankType.Account
+            else
+                tabIndex = self.slot - Enum.BagIndex.CharacterBankTab_1 + 1
+                bankType = Enum.BankType and Enum.BankType.Character
+            end
             -- When our bank tabs are contained within the bank frame, anchoring
             -- the settings menu to the tab causes it to appear behind the frame.
             -- Show the menu above the bank frame and position it to the right


### PR DESCRIPTION
## Summary
- derive correct bank type for character vs account bank tabs before opening the settings menu

## Testing
- `luacheck src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ae5b42f750832ea1e25052b798123a