### PR TITLE
Remove bag and bank category borders

### DIFF
--- a/src/base/BaseBag.lua
+++ b/src/base/BaseBag.lua
@@ -6,7 +6,7 @@ bag.__index = bag
 local settings = {
     padding = 5,
     scale = 1,
-    containerSpacing = 5,
+    containerSpacing = 2,
     itemSpacing = 5,
     maxColumns = 10,
 }

--- a/src/format/Masonry.lua
+++ b/src/format/Masonry.lua
@@ -68,8 +68,8 @@ ADDON.formatter[ADDON.formats.MASONRY] = function(bag)
             currentType = item.type
             container = bag.titleContainers[currentType]
             cnt = 0
-            x = 4 + padding
-            y = 4 + padding + padding + container.name:GetHeight()
+            x = padding
+            y = padding + padding + container.name:GetHeight()
             tinsert(containers, container)
         end
 
@@ -85,7 +85,7 @@ ADDON.formatter[ADDON.formats.MASONRY] = function(bag)
             x = x + itemSpacing + item:GetWidth()
             cnt = cnt + 1
             if cnt % maxCols == 0 then
-                x = 4 + padding
+                x = padding
                 y = y + itemSpacing + item:GetHeight()
             end
         else
@@ -96,7 +96,7 @@ ADDON.formatter[ADDON.formats.MASONRY] = function(bag)
         local rows = item.type == EMPTY and 1 or math.ceil(cnt / maxCols)
         local width = padding * 2 + cols * item:GetWidth() + (cols - 1) * itemSpacing
         local height = padding * 3 + container.name:GetHeight() + rows * item:GetHeight() + (rows - 1) * itemSpacing
-        container:SetSize(width+8, height+8)
+        container:SetSize(width, height)
         container.cols = cols
     end
 

--- a/src/titleContainer/TitleContainer.xml
+++ b/src/titleContainer/TitleContainer.xml
@@ -66,8 +66,17 @@
         </Layers>
     </Frame>
 
-    <Frame name="DJBagsTitleContainerTemplate" inherits="DJBagsBackgroundTemplate" virtual="true">
+    <Frame name="DJBagsTitleContainerTemplate" virtual="true">
         <Layers>
+            <Layer level="BACKGROUND">
+                <Texture parentKey="Background">
+                    <Anchors>
+                        <Anchor point="TOPLEFT"/>
+                        <Anchor point="BOTTOMRIGHT"/>
+                    </Anchors>
+                    <Color r="0" g="0" b="0" a="0.8"/>
+                </Texture>
+            </Layer>
             <Layer level="OVERLAY">
                 <FontString name="$parentName" parentKey="name" inherits="GameFontHighlight">
                     <Anchors>


### PR DESCRIPTION
## Summary
- Drop white borders from bag and bank item categories
- Reduce spacing between categories for tighter layouts

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68ae5d01a1f4832eb80a3f9b6b0e0f3f