### PR TITLE
Prioritize new category display

### DIFF
--- a/src/format/Masonry.lua
+++ b/src/format/Masonry.lua
@@ -7,7 +7,11 @@ ADDON.formatter = ADDON.formatter or {}
 -- the layout compact by prioritising categories that take more space
 -- instead of using alphabetical order.
 local typeSorter = function(A, B)
-    if A == EMPTY then
+    if A == NEW then
+        return true
+    elseif B == NEW then
+        return false
+    elseif A == EMPTY then
         return false
     elseif B == EMPTY then
         return true


### PR DESCRIPTION
## Summary
- Always sort the `NEW` category before others so newly acquired items appear first

## Testing
- `luac -p src/format/Masonry.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ae6da8148c832e85f57383ebdaf708