### PR TITLE
Fix tooltip text in category dialog

### DIFF
--- a/src/category/CategoryDialog.lua
+++ b/src/category/CategoryDialog.lua
@@ -26,9 +26,10 @@ local function DropDownClick(self)
 end
 
 function dialog:DisplayForItem(id, name)
-	self.name:SetText(name)
-	self.id = id
-	self:Show()
+        self.name:SetText(name)
+        self.name.text = name
+        self.id = id
+        self:Show()
 
     local current = DJBags_DB_Char.categories[id] or DJBags_DB.categories[id]
     local categories = ADDON:GetAllPlayerDefinedCategories()


### PR DESCRIPTION
## Summary
- Ensure CategoryDialog stores its display name so tooltip text is provided

## Testing
- `luacheck src/category/CategoryDialog.lua`

------
https://chatgpt.com/codex/tasks/task_e_68afc414e35c832eb87ff619fed5b6ab