### PR TITLE
Initialize bank tab settings menu to restore character bank tab options

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -8,6 +8,13 @@ function ADDON:GetBankTabSettingsMenu()
     if not self.bankTabSettingsMenu then
         if BankPanelTabSettingsMenuMixin then
             self.bankTabSettingsMenu = CreateFrame("Frame", nil, UIParent, "BankPanelTabSettingsMenuTemplate")
+            -- Frames created with CreateFrame do not automatically run their
+            -- OnLoad handler.  The Blizzard menu relies on its OnLoad to
+            -- register for events and become interactive, so manually invoke it
+            -- after creation.
+            if self.bankTabSettingsMenu.OnLoad then
+                self.bankTabSettingsMenu:OnLoad()
+            end
             if BankFrame and BankFrame.BankPanel then
                 if self.bankTabSettingsMenu.SetBankPanel then
                     self.bankTabSettingsMenu:SetBankPanel(BankFrame.BankPanel)


### PR DESCRIPTION
## Summary
- Ensure custom bank tab settings menu runs its OnLoad handler so options populate correctly

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b0eb5664d0832e8e4bcaa12002b8ed