### PR TITLE
Initialize child icon selector during bank tab menu creation

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -65,6 +65,13 @@ local function CreateSettingsMenu()
         frame:OnLoad()
     end
 
+    -- Child frames defined in the template also need to run their own
+    -- initialization logic so the icon selector has the data provider
+    -- required for filtering icons.
+    if frame.IconSelector and frame.IconSelector.OnLoad then
+        frame.IconSelector:OnLoad()
+    end
+
     frame.BorderBox.IconSelectorEditBox:SetAutoFocus(false)
 
     -- Track the currently selected icon.


### PR DESCRIPTION
## Summary
- ensure the icon selector's internal data provider is initialized

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`
- `luacheck --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0ef3710fc832eb576aa3c064ea1d5