### PR TITLE
Fix icon selector data provider reinitialization

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -100,6 +100,16 @@ local function CreateSettingsMenu()
         self.bankType = bankType
         self.tabIndex = tabIndex
 
+        -- The icon selector's data provider is cleared whenever the popup
+        -- frame is hidden. Reinitialize the child frame as needed and wire
+        -- the provider so filtering works when the menu is reopened.
+        if self.IconSelector then
+            if not self.IconSelector.iconDataProvider and self.IconSelector.OnLoad then
+                self.IconSelector:OnLoad()
+            end
+            self.iconDataProvider = self.IconSelector.iconDataProvider
+        end
+
         local name, icon = FetchTabInfo(bankType, tabIndex)
 
         self.BorderBox.IconSelectorEditBox:SetText(name or "")


### PR DESCRIPTION
## Summary
- Ensure bank tab settings menu restores the icon selector's data provider whenever the menu is opened

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f3817950832e9c75990aff3b8b67