### PR TITLE
Ensure bank tab icon selector always has data provider

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -95,6 +95,20 @@ local function CreateSettingsMenu()
         frame.BorderBox.SelectedIconArea.SelectedIconText.SelectedIconDescription:SetFontObject(GameFontHighlightSmall)
     end)
 
+    -- Ensure the data provider is always available when changing the icon filter.
+    if frame.SetIconFilter then
+        local originalSetIconFilter = frame.SetIconFilter
+        function frame:SetIconFilter(iconFilter)
+            if not self.iconDataProvider and self.IconSelector then
+                if not self.IconSelector.iconDataProvider and self.IconSelector.OnLoad then
+                    self.IconSelector:OnLoad()
+                end
+                self.iconDataProvider = self.IconSelector.iconDataProvider
+            end
+            originalSetIconFilter(self, iconFilter)
+        end
+    end
+
     -- Populate the menu with data for the requested tab.
     function frame:Load(bankType, tabIndex)
         self.bankType = bankType


### PR DESCRIPTION
## Summary
- Prevent nil iconDataProvider errors when filtering bank tab icons by reattaching the selector's data provider

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b0f46fd5ac832ebf1a66d52331352f