### PR TITLE
Ensure icon selector data provider before filtering

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -111,6 +111,19 @@ local function CreateSettingsMenu()
         end
     end
 
+    if frame.SetIconFilterInternal then
+        local originalSetIconFilterInternal = frame.SetIconFilterInternal
+        function frame:SetIconFilterInternal(...)
+            if not self.iconDataProvider and self.IconSelector then
+                if not self.IconSelector.iconDataProvider and self.IconSelector.OnLoad then
+                    self.IconSelector:OnLoad()
+                end
+                self.iconDataProvider = self.IconSelector.iconDataProvider
+            end
+            originalSetIconFilterInternal(self, ...)
+        end
+    end
+
     -- Populate the menu with data for the requested tab.
     function frame:Load(bankType, tabIndex)
         self.bankType = bankType


### PR DESCRIPTION
## Summary
- avoid nil `iconDataProvider` by initializing before filtering icons
- handle direct calls to `SetIconFilterInternal` to prevent errors when changing icon filters

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b0f6d9c278832ea231ea0e3331f13b