### PR TITLE
Add warband bank with bottom tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A bag addon that sorts items into categories defined by Blizzard or user specifi
 * PAWN Support.
 * Clear new items with the clear items button next to search bar. ~~or by mousing over them.~~
 * Restack items: Restack items for bags with the restack button.
+* Switch between character and warband banks via tabs.
 * All bags settings for columns and categories.
 * User defined settings for all chars or per char: press ALT + Left mouse button on an item to open dialogue.
 * Clear a single new item: ALT + Right mouse button on new item to remove it from new items list.

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -69,6 +69,66 @@
                     </OnLoad>
                 </Scripts>
             </ItemButton>
+            <ItemButton name="$parentAccountBag1" parentKey="accountBag1" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" x="9" y="-9" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_1, BankButtonIDToInvSlotID(1, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag2" parentKey="accountBag2" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag1" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_2, BankButtonIDToInvSlotID(2, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag3" parentKey="accountBag3" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag2" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_3, BankButtonIDToInvSlotID(3, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag4" parentKey="accountBag4" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag3" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_4, BankButtonIDToInvSlotID(4, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag5" parentKey="accountBag5" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag4" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_5, BankButtonIDToInvSlotID(5, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag6" parentKey="accountBag6" hidden="true">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag5" relativePoint="TOPRIGHT" x="5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBagItemLoad(self, Enum.BagIndex.AccountBankTab_6, BankButtonIDToInvSlotID(6, Enum.BankType and Enum.BankType.Account or 0))
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
@@ -141,7 +201,30 @@
                                 Enum.BagIndex.CharacterBankTab_3,
                                 Enum.BagIndex.CharacterBankTab_4,
                                 Enum.BagIndex.CharacterBankTab_5,
-                                Enum.BagIndex.CharacterBankTab_6})
+                                Enum.BagIndex.CharacterBankTab_6}, Enum.BankType.Character)
+                    </OnLoad>
+                    <OnShow>
+                        self:OnShow()
+                    </OnShow>
+                    <OnHide>
+                        self:OnHide()
+                    </OnHide>
+                </Scripts>
+            </Frame>
+            <Frame name="DJBagsWarbandBank" inherits="DJBagsBackgroundTemplate" parentKey="warbandBankBag" frameStrata="MEDIUM" toplevel="true" movable="true" enableMouse="true"
+                   hidden="true" parent="DJBagsBankBar">
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="BOTTOMLEFT" y="-5" />
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsRegisterBankBagContainer(self, {
+                                Enum.BagIndex.AccountBankTab_1,
+                                Enum.BagIndex.AccountBankTab_2,
+                                Enum.BagIndex.AccountBankTab_3,
+                                Enum.BagIndex.AccountBankTab_4,
+                                Enum.BagIndex.AccountBankTab_5,
+                                Enum.BagIndex.AccountBankTab_6}, Enum.BankType.Account)
                     </OnLoad>
                     <OnShow>
                         self:OnShow()
@@ -196,6 +279,36 @@
                     </OnLoad>
                 </Scripts>
             </Frame>
+            <Button name="$parentTab1" parentKey="characterTab" inherits="CharacterFrameTabButtonTemplate" id="1">
+                <Anchors>
+                    <Anchor point="TOPRIGHT" relativeTo="DJBagsBank" relativePoint="BOTTOMRIGHT" x="-75" y="2"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        self:SetText(CHARACTER)
+                        PanelTemplates_TabResize(self, 0)
+                    </OnLoad>
+                    <OnClick>
+                        PanelTemplates_SetTab(self:GetParent(), 1)
+                        BankFrame:SetTab(Enum.BankType and Enum.BankType.Character or 1)
+                    </OnClick>
+                </Scripts>
+            </Button>
+            <Button name="$parentTab2" parentKey="warbandTab" inherits="CharacterFrameTabButtonTemplate" id="2">
+                <Anchors>
+                    <Anchor point="LEFT" relativeTo="$parentTab1" relativePoint="RIGHT" x="-16"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        self:SetText(WARBAND_BANK or "Warband")
+                        PanelTemplates_TabResize(self, 0)
+                    </OnLoad>
+                    <OnClick>
+                        PanelTemplates_SetTab(self:GetParent(), 2)
+                        BankFrame:SetTab(Enum.BankType and Enum.BankType.Account or 2)
+                    </OnClick>
+                </Scripts>
+            </Button>
         </Frames>
         <Scripts>
             <OnLoad>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -4,9 +4,9 @@ local bankFrame = {}
 bankFrame.__index = bankFrame
 
 function DJBagsRegisterBankFrame(self, bags)
-	for k, v in pairs(bankFrame) do
-		self[k] = v
-	end
+        for k, v in pairs(bankFrame) do
+                self[k] = v
+        end
 
     ADDON.eventManager:Add('BANKFRAME_OPENED', self)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
@@ -21,6 +21,9 @@ function DJBagsRegisterBankFrame(self, bags)
     end)
     self:SetUserPlaced(true)
 
+    PanelTemplates_SetNumTabs(self, 2)
+    PanelTemplates_SetTab(self, 1)
+
     -- Update our visibility when the bank switches between character and account tabs.
     hooksecurefunc(BankFrame, "SetTab", function()
         self:UpdateBankType()
@@ -30,15 +33,40 @@ end
 function bankFrame:UpdateBankType()
     local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
     local isCharacterBank = not bankType or bankType == Enum.BankType.Character
-    self.bankBag.isCharacterBank = isCharacterBank
+
+    if self.bankBag then
+        self.bankBag.isActive = isCharacterBank
+    end
+    if self.warbandBankBag then
+        self.warbandBankBag.isActive = not isCharacterBank
+    end
 
     if isCharacterBank then
-        self.bankBag:Show()
-        self:Show()
+        if self.bankBag then self.bankBag:Show() end
+        if self.warbandBankBag then self.warbandBankBag:Hide() end
+        for i = 1, 6 do
+            local bag = self['bag' .. i]
+            local acc = self['accountBag' .. i]
+            if bag then bag:Show() end
+            if acc then acc:Hide() end
+        end
     else
-        self.bankBag:Hide()
-        self:Hide()
+        if self.bankBag then self.bankBag:Hide() end
+        if self.warbandBankBag then self.warbandBankBag:Show() end
+        for i = 1, 6 do
+            local bag = self['bag' .. i]
+            local acc = self['accountBag' .. i]
+            if bag then bag:Hide() end
+            if acc then acc:Show() end
+        end
     end
+
+    if self.bankSettingsMenu then
+        self.bankSettingsMenu.bag = isCharacterBank and self.bankBag or self.warbandBankBag
+    end
+
+    PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
+    self:Show()
 end
 
 function bankFrame:BANKFRAME_OPENED()


### PR DESCRIPTION
## Summary
- support character and warband banks with dedicated containers
- add account bank slots and tabs to toggle between banks
- document warband bank access in README

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b24a996868832e909f2a07a895fbc7