### PR TITLE
Handle missing bag IDs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -25,7 +25,9 @@ function DJBagsBagItemLoad(button, slot, id)
 end
 
 function item:Init(id, slot)
-    self:SetID(id)
+    -- Some game versions may not provide slot or inventory IDs for all bank
+    -- tabs.  Guard against nil so SetID never receives an invalid value.
+    self:SetID(id or slot or 0)
     self.slot = slot
 
     -- Allow both left and right button clicks so we can open bank tab settings


### PR DESCRIPTION
## Summary
- guard against nil slot and inventory IDs when initializing bag items to prevent SetID errors

## Testing
- `luacheck src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b24d034c70832e9cc8c601ce3100b5