### PR TITLE
Guard against missing tab text in DJBags bank UI

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -286,6 +286,9 @@
                 <Scripts>
                     <OnLoad>
                         self:SetText(CHARACTER)
+                        if not self.Text and self.GetFontString then
+                            self.Text = self:GetFontString()
+                        end
                         PanelTemplates_TabResize(self, 0)
                     </OnLoad>
                     <OnClick>
@@ -301,6 +304,9 @@
                 <Scripts>
                     <OnLoad>
                         self:SetText(WARBAND_BANK or "Warband")
+                        if not self.Text and self.GetFontString then
+                            self.Text = self:GetFontString()
+                        end
                         PanelTemplates_TabResize(self, 0)
                     </OnLoad>
                     <OnClick>


### PR DESCRIPTION
## Summary
- Avoid nil access by setting bank tab's `Text` field from its font string before calling `PanelTemplates_TabResize`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24db13394832e9e73df25cb4466ea