### PR TITLE
Fix bank tab texture access error

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -289,6 +289,11 @@
                         if not self.Text and self.GetFontString then
                             self.Text = self:GetFontString()
                         end
+                        if not self.Left and self.LeftDisabled then
+                            self.Left = self.LeftDisabled
+                            self.Middle = self.MiddleDisabled
+                            self.Right = self.RightDisabled
+                        end
                         PanelTemplates_TabResize(self, 0)
                     </OnLoad>
                     <OnClick>
@@ -306,6 +311,11 @@
                         self:SetText(WARBAND_BANK or "Warband")
                         if not self.Text and self.GetFontString then
                             self.Text = self:GetFontString()
+                        end
+                        if not self.Left and self.LeftDisabled then
+                            self.Left = self.LeftDisabled
+                            self.Middle = self.MiddleDisabled
+                            self.Right = self.RightDisabled
                         end
                         PanelTemplates_TabResize(self, 0)
                     </OnLoad>


### PR DESCRIPTION
## Summary
- Ensure bank tabs define Left/Middle/Right textures before resizing to avoid nil errors

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ed6c9e0832e93cd746375f952cd