### PR TITLE
Guard bank tab resize when textures are missing

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -294,7 +294,9 @@
                             self.Middle = self.MiddleDisabled
                             self.Right = self.RightDisabled
                         end
-                        PanelTemplates_TabResize(self, 0)
+                        if self.Left then
+                            PanelTemplates_TabResize(self, 0)
+                        end
                     </OnLoad>
                     <OnClick>
                         PanelTemplates_SetTab(self:GetParent(), 1)
@@ -317,7 +319,9 @@
                             self.Middle = self.MiddleDisabled
                             self.Right = self.RightDisabled
                         end
-                        PanelTemplates_TabResize(self, 0)
+                        if self.Left then
+                            PanelTemplates_TabResize(self, 0)
+                        end
                     </OnLoad>
                     <OnClick>
                         PanelTemplates_SetTab(self:GetParent(), 2)


### PR DESCRIPTION
## Summary
- Guard calls to `PanelTemplates_TabResize` so bank tabs without left textures no longer throw errors

## Testing
- `luacheck src`

------
https://chatgpt.com/codex/tasks/task_e_68b24f55ff30832e9161e6479a63d3ee