### PR TITLE
Fix bank tab selection before textures load

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -23,28 +23,12 @@ function DJBagsRegisterBankFrame(self, bags)
 
     PanelTemplates_SetNumTabs(self, 2)
 
-    -- Panels tab templates expect certain textures to exist before
-    -- selecting a tab. During the frame's OnLoad the child tabs may not
-    -- have run their own OnLoad scripts yet, leaving these textures nil
-    -- and causing errors when PanelTemplates_SelectTab runs. Prepare the
-    -- tabs here so we can safely select the initial tab.
-    local function PrepareTab(tab)
-        if not tab then return end
-        if not tab.Text and tab.GetFontString then
-            tab.Text = tab:GetFontString()
-        end
-        if not tab.Left and tab.LeftDisabled then
-            tab.Left = tab.LeftDisabled
-            tab.Middle = tab.MiddleDisabled
-            tab.Right = tab.RightDisabled
-        end
-        if tab.Left then
-            PanelTemplates_TabResize(tab, 0)
-        end
-    end
-    PrepareTab(self.characterTab)
-    PrepareTab(self.warbandTab)
-    PanelTemplates_SetTab(self, 1)
+    -- Defer selecting the initial tab until the next frame so that the
+    -- child tab buttons have finished running their own OnLoad scripts and
+    -- created the textures expected by PanelTemplates_SelectTab.
+    C_Timer.After(0, function()
+        PanelTemplates_SetTab(self, 1)
+    end)
 
     -- Update our visibility when the bank switches between character and account tabs.
     hooksecurefunc(BankFrame, "SetTab", function()


### PR DESCRIPTION
## Summary
- Delay default bank tab selection until the next frame so child tab buttons finish loading
- Prevent `Left` nil errors from PanelTemplates when opening the bank

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b251492458832e93df8ffa7610f567