### PR TITLE
Align bank tabs left and resize with frame

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -281,7 +281,7 @@
             </Frame>
             <Button name="$parentTab1" parentKey="characterTab" inherits="PanelTabButtonTemplate" id="1">
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="DJBagsBank" relativePoint="BOTTOMRIGHT" x="-75" y="2"/>
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="BOTTOMLEFT" x="75" y="2"/>
                 </Anchors>
                 <Scripts>
                     <OnLoad>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -71,7 +71,14 @@ function bankFrame:UpdateBankType()
         self.bankSettingsMenu.bag = isCharacterBank and self.bankBag or self.warbandBankBag
     end
 
+    local activeBag = isCharacterBank and self.bankBag or self.warbandBankBag
+    if activeBag and self.characterTab then
+        self.characterTab:ClearAllPoints()
+        self.characterTab:SetPoint("TOPLEFT", activeBag, "BOTTOMLEFT", 75, 2)
+    end
+
     PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
+    PanelTemplates_ResizeTabsToFit(self)
     self:Show()
 end
 


### PR DESCRIPTION
## Summary
- Anchor bank tabs to the left side of the bank frame
- Reposition tabs on bank type change and resize to fit frame width

## Testing
- `luac -p src/bank/BankFrame.lua`
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b254ddec08832e9c250535ae239662