### PR TITLE
Prevent nil comparison in bank tab resizing

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -78,7 +78,8 @@ function bankFrame:UpdateBankType()
     end
 
     PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
-    PanelTemplates_ResizeTabsToFit(self)
+    local maxWidth = (activeBag and activeBag:GetWidth()) or self:GetWidth()
+    PanelTemplates_ResizeTabsToFit(self, maxWidth)
     self:Show()
 end
 


### PR DESCRIPTION
## Summary
- avoid passing nil to `PanelTemplates_ResizeTabsToFit`
- compute max width using active bank bag or frame width

## Testing
- `luac -p src/bank/BankFrame.lua` *(fails: command not found)*
- `apt-get install -y lua5.1` *(fails: Unable to locate package lua5.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b255cf2520832eb3c91b6065f65e60