### PR TITLE
Align bank tabs to left edge

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -281,7 +281,7 @@
             </Frame>
             <Button name="$parentTab1" parentKey="characterTab" inherits="PanelTabButtonTemplate" id="1">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="BOTTOMLEFT" x="75" y="2"/>
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="BOTTOMLEFT" x="0" y="2"/>
                 </Anchors>
                 <Scripts>
                     <OnLoad>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -74,7 +74,7 @@ function bankFrame:UpdateBankType()
     local activeBag = isCharacterBank and self.bankBag or self.warbandBankBag
     if activeBag and self.characterTab then
         self.characterTab:ClearAllPoints()
-        self.characterTab:SetPoint("TOPLEFT", activeBag, "BOTTOMLEFT", 75, 2)
+        self.characterTab:SetPoint("TOPLEFT", activeBag, "BOTTOMLEFT", 0, 2)
     end
 
     PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)


### PR DESCRIPTION
## Summary
- Align bank frame tabs to the left edge by removing horizontal offset

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b257438e58832e8e07a704a93e0180