### PR TITLE
Default to character bank tab on login

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -38,7 +38,11 @@ end
 
 function bank:BANKFRAME_OPENED()
     local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
-    self.isActive = not bankType or bankType == self.bankType
+    if not bankType then
+        bankType = Enum.BankType and Enum.BankType.Character or 0
+    end
+
+    self.isActive = bankType == self.bankType
     if self.isActive then
         self:Show()
     else

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -85,6 +85,9 @@ function bankFrame:UpdateBankType()
 end
 
 function bankFrame:BANKFRAME_OPENED()
+    if BankFrame and BankFrame.GetActiveBankType and not BankFrame:GetActiveBankType() then
+        BankFrame:SetTab(1, Enum.BankType and Enum.BankType.Character)
+    end
     self:UpdateBankType()
     DJBagsBag:Show()
 end


### PR DESCRIPTION
## Summary
- show only the character bank when the bank is first opened
- initialize Blizzard BankFrame to the character tab if no tab is active

## Testing
- `luacheck .` *(fails: lots of warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3605257e4832eb89801d51bb126b5