### PR TITLE
Add currency tracker for watched currency

### DIFF
--- a/src/bag/Bag.lua
+++ b/src/bag/Bag.lua
@@ -11,6 +11,9 @@ function DJBagsRegisterBagBagContainer(self, bags)
     end
 
     ADDON.eventManager:Add("NewItemCleared", self)
+    ADDON.eventManager:Add("CURRENCY_DISPLAY_UPDATE", self)
+
+    self:UpdateCurrency()
 end
 
 function bag:SortBags()
@@ -41,4 +44,23 @@ function bag:BAG_UPDATE_DELAYED()
             end
         end
     end
+end
+
+function bag:UpdateCurrency()
+    if not self.currencyBar then return end
+    local info = C_CurrencyInfo.GetBackpackCurrencyInfo(1)
+    if info then
+        local icon = info.iconFileID or info.icon
+        if icon then
+            self.currencyBar.icon:SetTexture(icon)
+        end
+        self.currencyBar.amount:SetText(info.quantity)
+        self.currencyBar:Show()
+    else
+        self.currencyBar:Hide()
+    end
+end
+
+function bag:CURRENCY_DISPLAY_UPDATE()
+    self:UpdateCurrency()
 end

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -213,6 +213,27 @@
                     <Anchor point="TOPRIGHT" relativeTo="$parent" relativePoint="BOTTOMRIGHT" x="0" y="0"/>
                 </Anchors>
             </Frame>                        
+            <Frame name="$parentCurrency" parentKey="currencyBar" inherits="DJBagsMainBarTemplate" hidden="true">
+                <Size x="120" y="33"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="BOTTOMLEFT"/>
+                </Anchors>
+                <Layers>
+                    <Layer level="OVERLAY">
+                        <Texture parentKey="icon">
+                            <Size x="16" y="16"/>
+                            <Anchors>
+                                <Anchor point="LEFT" x="8" y="0"/>
+                            </Anchors>
+                        </Texture>
+                        <FontString parentKey="amount" inherits="GameFontHighlight">
+                            <Anchors>
+                                <Anchor point="LEFT" relativeKey="$parent.icon" relativePoint="RIGHT" x="5" y="0"/>
+                            </Anchors>
+                        </FontString>
+                    </Layer>
+                </Layers>
+            </Frame>
             <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
                 <Anchors>
                     <Anchor point="CENTER" relativePoint="TOPRIGHT" x="-2" y="-2"/>


### PR DESCRIPTION
## Summary
- show watched currency at bottom left of bag frame with its icon and amount
- keep display updated as currency changes

## Testing
- `luac -p src/bag/Bag.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b362781b84832ead0b43f01f25f684