### PR TITLE
Hide main bar elements in currency display

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -213,7 +213,7 @@
                     <Anchor point="TOPRIGHT" relativeTo="$parent" relativePoint="BOTTOMRIGHT" x="0" y="0"/>
                 </Anchors>
             </Frame>                        
-            <Frame name="$parentCurrency" parentKey="currencyBar" inherits="DJBagsMainBarTemplate" hidden="true">
+            <Frame name="$parentCurrency" parentKey="currencyBar" inherits="DJBagsBackgroundTemplate" hidden="true">
                 <Size x="120" y="33"/>
                 <Anchors>
                     <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="BOTTOMLEFT"/>


### PR DESCRIPTION
## Summary
- Ensure currency bar only shows currency by using background template

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`
- `xmllint --noout src/bag/Bag.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b364338190832e8c347bfedcc2763a