### PR TITLE
Move bank bag tabs to vertical sidebar

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -42,8 +42,7 @@ function item:Init(id, slot)
             return
         end
 
-        -- Right-clicking a bank tab should open the settings menu
-        if button == "RightButton" and BankFrame and isBankTabSlot(self.slot) then
+        if isBankTabSlot(self.slot) then
             local tabIndex, bankType
 
             if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_6
@@ -57,11 +56,21 @@ function item:Init(id, slot)
                 bankType = Enum.BankType and Enum.BankType.Character
             end
 
-            local menu = ADDON:GetBankTabSettingsMenu()
-            menu:Open(bankType, tabIndex)
+            if button == "RightButton" and BankFrame then
+                local menu = ADDON:GetBankTabSettingsMenu()
+                menu:Open(bankType, tabIndex)
 
-            PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
-            return
+                PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
+                return
+            end
+
+            if button == "LeftButton" then
+                if self:GetParent() and self:GetParent().SetBankTab then
+                    self:GetParent():SetBankTab(tabIndex, bankType)
+                end
+                PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
+                return
+            end
         end
 
         self:PlaceOrPickup(button, ...)

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -79,28 +79,17 @@ function bank:BAG_UPDATE_DELAYED()
     end
 
     local prev
-    local first
     for i = 1, 6 do
         local barItem = DJBagsBankBar[prefix .. i]
         if barItem and barItem:IsShown() then
             barItem:ClearAllPoints()
             if prev then
-                barItem:SetPoint('TOPLEFT', prev, 'TOPRIGHT', 5, 0)
+                barItem:SetPoint('TOPLEFT', prev, 'BOTTOMLEFT', 0, -5)
             else
-                barItem:SetPoint('TOPLEFT', DJBagsBankBar, 'TOPLEFT', 9, -9)
-                first = barItem
+                barItem:SetPoint('TOPLEFT', self, 'TOPRIGHT', 5, 0)
             end
             prev = barItem
         end
-    end
-
-    if DJBagsBankBarRestackButton and prev then
-        DJBagsBankBarRestackButton:ClearAllPoints()
-        DJBagsBankBarRestackButton:SetPoint('TOPRIGHT', prev, 'BOTTOMRIGHT', 0, -9.5)
-    end
-    if DJBagsBankBarSettingsBtn and first then
-        DJBagsBankBarSettingsBtn:ClearAllPoints()
-        DJBagsBankBarSettingsBtn:SetPoint('TOPLEFT', first, 'BOTTOMLEFT', 0, -5)
     end
 end
 

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -11,7 +11,7 @@
         <Frames>
             <ItemButton name="$parentBag1" parentKey="bag1">
                 <Anchors>
-                    <Anchor point="TOPLEFT" x="9" y="-9" />
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="TOPRIGHT" x="5" y="0" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -21,7 +21,7 @@
             </ItemButton>
             <ItemButton name="$parentBag2" parentKey="bag2">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -31,7 +31,7 @@
             </ItemButton>
             <ItemButton name="$parentBag3" parentKey="bag3">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag2" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag2" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -41,7 +41,7 @@
             </ItemButton>
             <ItemButton name="$parentBag4" parentKey="bag4">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag3" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag3" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -51,7 +51,7 @@
             </ItemButton>
             <ItemButton name="$parentBag5" parentKey="bag5">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -61,7 +61,7 @@
             </ItemButton>
             <ItemButton name="$parentBag6" parentKey="bag6">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag5" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag5" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -71,7 +71,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag1" parentKey="accountBag1" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" x="9" y="-9" />
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsWarbandBank" relativePoint="TOPRIGHT" x="5" y="0" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -81,7 +81,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag2" parentKey="accountBag2" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag1" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag1" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -91,7 +91,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag3" parentKey="accountBag3" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag2" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag2" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -101,7 +101,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag4" parentKey="accountBag4" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag3" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag3" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -111,7 +111,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag5" parentKey="accountBag5" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag4" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag4" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -121,7 +121,7 @@
             </ItemButton>
             <ItemButton name="$parentAccountBag6" parentKey="accountBag6" hidden="true">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag5" relativePoint="TOPRIGHT" x="5" />
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag5" relativePoint="BOTTOMLEFT" y="-5" />
                 </Anchors>
                 <Scripts>
                     <OnLoad>
@@ -132,7 +132,7 @@
             <Button name="$parentRestackButton">
                 <Size x="16" y="16" />
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentBag6" relativePoint="BOTTOMRIGHT" y="-9.5" />
+                    <Anchor point="TOPRIGHT" x="-9" y="-9" />
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled" />
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up" />
@@ -158,7 +158,7 @@
             <Button name="$parentSettingsBtn">
                 <Size x="16" y="16"/>
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="BOTTOMLEFT" x="0" y="-5"/>
+                    <Anchor point="TOPLEFT" x="9" y="-9"/>
                 </Anchors>
                 <NormalTexture file="Interface\Buttons\UI-GuildButton-PublicNote-Disabled"/>
                 <PushedTexture file="Interface\Buttons\UI-GuildButton-OfficerNote-Up"/>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -3,6 +3,24 @@ local ADDON_NAME, ADDON = ...
 local bankFrame = {}
 bankFrame.__index = bankFrame
 
+local CHARACTER_TABS = {
+    Enum.BagIndex.CharacterBankTab_1,
+    Enum.BagIndex.CharacterBankTab_2,
+    Enum.BagIndex.CharacterBankTab_3,
+    Enum.BagIndex.CharacterBankTab_4,
+    Enum.BagIndex.CharacterBankTab_5,
+    Enum.BagIndex.CharacterBankTab_6,
+}
+
+local ACCOUNT_TABS = {
+    Enum.BagIndex.AccountBankTab_1,
+    Enum.BagIndex.AccountBankTab_2,
+    Enum.BagIndex.AccountBankTab_3,
+    Enum.BagIndex.AccountBankTab_4,
+    Enum.BagIndex.AccountBankTab_5,
+    Enum.BagIndex.AccountBankTab_6,
+}
+
 
 function DJBagsRegisterBankFrame(self, bags)
         for k, v in pairs(bankFrame) do
@@ -35,6 +53,42 @@ function DJBagsRegisterBankFrame(self, bags)
     hooksecurefunc(BankFrame, "SetTab", function()
         self:UpdateBankType()
     end)
+
+    C_Timer.After(0, function()
+        self:SetBankTab(1, Enum.BankType and Enum.BankType.Character)
+    end)
+end
+
+function bankFrame:SetBankTab(tabIndex, bankType)
+    bankType = bankType or (BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()) or (Enum.BankType and Enum.BankType.Character)
+    self.activeBankTab = tabIndex
+
+    local bags = bankType == Enum.BankType.Account and ACCOUNT_TABS or CHARACTER_TABS
+    local bagIndex = bags[tabIndex]
+
+    if bankType == Enum.BankType.Account then
+        if self.warbandBankBag and bagIndex then
+            self.warbandBankBag:SetBags({ bagIndex })
+            self.warbandBankBag:BAG_UPDATE_DELAYED()
+        end
+        for i = 1, 6 do
+            local btn = self['accountBag' .. i]
+            if btn then
+                btn:SetAlpha(i == tabIndex and 1 or 0.5)
+            end
+        end
+    else
+        if self.bankBag and bagIndex then
+            self.bankBag:SetBags({ bagIndex })
+            self.bankBag:BAG_UPDATE_DELAYED()
+        end
+        for i = 1, 6 do
+            local btn = self['bag' .. i]
+            if btn then
+                btn:SetAlpha(i == tabIndex and 1 or 0.5)
+            end
+        end
+    end
 end
 
 function bankFrame:UpdateBankType()
@@ -81,6 +135,7 @@ function bankFrame:UpdateBankType()
     PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
     local maxWidth = (activeBag and activeBag:GetWidth()) or self:GetWidth()
     PanelTemplates_ResizeTabsToFit(self, maxWidth)
+    self:SetBankTab(1, isCharacterBank and (Enum.BankType and Enum.BankType.Character) or (Enum.BankType and Enum.BankType.Account))
     self:Show()
 end
 

--- a/src/base/BaseBag.lua
+++ b/src/base/BaseBag.lua
@@ -145,6 +145,39 @@ function bag:Refresh()
     end
 end
 
+function bag:SetBags(bags)
+    for _, frame in pairs(self.titleContainers) do
+        frame:Hide()
+    end
+    self.titleContainers = {}
+    self.items = {}
+
+    self.bags = bags
+    self.bagsByKey = GetKeyBasedBagList(bags)
+
+    for _, bagID in pairs(bags) do
+        if not self.containers[bagID] then
+            self.containers[bagID] = CreateFrame("Frame", "DJBagsBagContainer_" .. bagID, self)
+            self.containers[bagID]:SetAllPoints()
+            self.containers[bagID]:SetID(bagID)
+            self.containers[bagID].items = {}
+        end
+    end
+
+    for id, container in pairs(self.containers) do
+        local show = self.bagsByKey[id]
+        container:SetShown(show)
+        if not show then
+            for _, item in pairs(container.items) do
+                item.id = nil
+                item:Hide()
+            end
+        end
+    end
+
+    self:Refresh()
+end
+
 function bag:PLAYER_ENTERING_WORLD()
     ADDON.eventManager:Add('BAG_UPDATE', self)
 


### PR DESCRIPTION
## Summary
- display bank bag tabs vertically on the right side of the bank frame
- click a tab to filter the bank to that specific bag
- support dynamic switching by introducing `SetBags` on bag containers

## Testing
- `luac -p src/bank/Bank.lua src/base/BaseBag.lua src/bagItem/BagItem.lua src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3721cc5f8832e8c9a51dd11c589f4