### PR TITLE
Add vertical bank tabs for character bank

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -114,6 +114,83 @@
                     </OnHide>
                 </Scripts>
             </Frame>
+            <ItemButton name="$parentAllTab" parentKey="allTab">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="TOPRIGHT" x="5" y="0"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankAllTab_OnLoad(self)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag1" parentKey="bag1">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAllTab" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 1)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag2" parentKey="bag2">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag1" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 2)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag3" parentKey="bag3">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag2" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 3)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag4" parentKey="bag4">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag3" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 4)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag5" parentKey="bag5">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag4" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 5)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentBag6" parentKey="bag6">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentBag5" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsBankTabButton_OnLoad(self, 6)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
             <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
                 <Anchors>
                     <Anchor point="CENTER" relativePoint="TOPRIGHT" x="-2" y="-2"/>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -51,6 +51,7 @@ function bankFrame:UpdateBankType()
     if isCharacterBank then
         if self.bankBag then self.bankBag:Show() end
         if self.warbandBankBag then self.warbandBankBag:Hide() end
+        if self.allTab then self.allTab:Show() end
         for i = 1, 6 do
             local bag = self['bag' .. i]
             local acc = self['accountBag' .. i]
@@ -60,6 +61,7 @@ function bankFrame:UpdateBankType()
     else
         if self.bankBag then self.bankBag:Hide() end
         if self.warbandBankBag then self.warbandBankBag:Show() end
+        if self.allTab then self.allTab:Hide() end
         for i = 1, 6 do
             local bag = self['bag' .. i]
             local acc = self['accountBag' .. i]
@@ -81,6 +83,11 @@ function bankFrame:UpdateBankType()
     PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
     local maxWidth = (activeBag and activeBag:GetWidth()) or self:GetWidth()
     PanelTemplates_ResizeTabsToFit(self, maxWidth)
+
+    if isCharacterBank and self.bankBag and self.bankBag.selectedTab then
+        self:UpdateTabSelection(self.bankBag.selectedTab)
+    end
+
     self:Show()
 end
 
@@ -94,4 +101,16 @@ end
 
 function bankFrame:BANKFRAME_CLOSED()
     self:Hide()
+end
+
+function bankFrame:UpdateTabSelection(selected)
+    if self.allTab then
+        self.allTab:SetAlpha(selected == 0 and 1 or 0.4)
+    end
+    for i = 1, 6 do
+        local btn = self['bag' .. i]
+        if btn then
+            btn:SetAlpha(selected == i and 1 or 0.4)
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- add right-side vertical tabs including an "all" tab for character bank
- allow selecting individual bank tabs and opening settings with right-click
- update bank frame to highlight selected tab and filter bank contents

## Testing
- `luac -p src/bank/Bank.lua src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b37bf8667c832e890e2a7f30a52e06