### PR TITLE
Fix bank tab filtering and hover highlight

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -125,6 +125,20 @@ function bank:SelectTab(tabIndex)
         self.bagsByKey[bag] = true
     end
 
+    -- Reset the item cache and hide items from inactive tabs so the display
+    -- only contains slots from the selected tab.
+    self.items = {}
+    if self.containers then
+        for bagID, container in pairs(self.containers) do
+            if not self.bagsByKey[bagID] then
+                for _, item in pairs(container.items) do
+                    item.id = nil
+                    item:Hide()
+                end
+            end
+        end
+    end
+
     self:Refresh()
     self:BAG_UPDATE_DELAYED()
 
@@ -176,4 +190,9 @@ function bank:PLAYERBANKBAGSLOTS_CHANGED()
     if self.isActive then
         self:BAG_UPDATE_DELAYED()
     end
+end
+
+-- Override the bag hover event to prevent highlighting items when hovering
+-- over bank tabs.  Tab selection already filters the visible items.
+function bank:DJBAGS_BAG_HOVER()
 end


### PR DESCRIPTION
## Summary
- Ensure selecting a bank tab filters the displayed items to that tab only
- Remove hover-based item highlighting on bank tabs

## Testing
- `luacheck src/bank/Bank.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b38071bbd4832e9a5072d014897872