### PR TITLE
Fix bank tab item cache clearing when changing tabs

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -126,11 +126,17 @@ function bank:SelectTab(tabIndex)
     end
 
     -- Reset the item cache and hide items from inactive tabs so the display
-    -- only contains slots from the selected tab.
+    -- only contains slots from the selected tab. Ensure items from the
+    -- active tab are retained in the cache so the bag doesn't appear empty
+    -- after switching tabs.
     self.items = {}
     if self.containers then
         for bagID, container in pairs(self.containers) do
-            if not self.bagsByKey[bagID] then
+            if self.bagsByKey[bagID] then
+                for _, item in pairs(container.items) do
+                    table.insert(self.items, item)
+                end
+            else
                 for _, item in pairs(container.items) do
                     item.id = nil
                     item:Hide()


### PR DESCRIPTION
## Summary
- Keep bank items cached when switching tabs so the bank frame stays visible

## Testing
- `luacheck src/bank/Bank.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3828ac884832e8387d6c743d9e070