### PR TITLE
Attach bank bar to bank frame

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -49,7 +49,7 @@
         </Scripts>
     </Frame>
 
-    <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" movable="true" enableMouse="true" hidden="true">
+    <Frame name="DJBagsBankBar" inherits="DJBagsBackgroundTemplate" parent="UIParent" enableMouse="true" hidden="true">
         <Size x="150" y="33"/>
         <Anchors>
             <Anchor point="TOPRIGHT" relativeTo="DJBagsBank" relativePoint="BOTTOMRIGHT" y="-5"/>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -14,13 +14,27 @@ function DJBagsRegisterBankFrame(self, bags)
 
     table.insert(UISpecialFrames, self:GetName())
     self:RegisterForDrag("LeftButton")
+    -- Attach dragging to the active bank frame so the bar cannot move on its own.
+    self:SetMovable(false)
     self:SetScript("OnDragStart", function(self, ...)
-        self:StartMoving()
+        local bag = self.bankBag
+        if self.warbandBankBag and self.warbandBankBag:IsShown() then
+            bag = self.warbandBankBag
+        end
+        if bag and bag.StartMoving then
+            bag:StartMoving(...)
+        end
     end)
     self:SetScript("OnDragStop", function(self, ...)
-        self:StopMovingOrSizing(...)
+        local bag = self.bankBag
+        if self.warbandBankBag and self.warbandBankBag:IsShown() then
+            bag = self.warbandBankBag
+        end
+        if bag and bag.StopMovingOrSizing then
+            bag:StopMovingOrSizing(...)
+        end
     end)
-    self:SetUserPlaced(true)
+    self:SetUserPlaced(false)
 
     PanelTemplates_SetNumTabs(self, 2)
 


### PR DESCRIPTION
## Summary
- Prevent `DJBagsBankBar` from being moved on its own and forward drag events to the active bank container
- Remove `movable` flag from `DJBagsBankBar` so it stays anchored to the bank frame

## Testing
- `luac5.1 -p src/bank/BankFrame.lua src/bank/Bank.lua`
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b38c85c270832ea63bbb4768820f45