### PR TITLE
Avoid SetUserPlaced on non-movable bank bar

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -34,7 +34,11 @@ function DJBagsRegisterBankFrame(self, bags)
             bag:StopMovingOrSizing(...)
         end
     end)
-    self:SetUserPlaced(false)
+    -- Only clear the user placement flag if the frame supports being moved or resized.
+    -- Calling SetUserPlaced on non-movable frames triggers an error starting in 11.0.2.
+    if self:IsMovable() or self:IsResizable() then
+        self:SetUserPlaced(false)
+    end
 
     PanelTemplates_SetNumTabs(self, 2)
 


### PR DESCRIPTION
## Summary
- prevent SetUserPlaced from running on the bank bar unless the frame is movable or resizable

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b38da25920832e9fce80f85ecad35c