### PR TITLE
Ensure bank bar close hides all bank and bag frames

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -307,6 +307,15 @@
                     CloseBank()
                 end
                 StaticPopup_Hide("CONFIRM_BUY_BANK_SLOT")
+                if self.bankBag then
+                    self.bankBag:Hide()
+                end
+                if self.warbandBankBag then
+                    self.warbandBankBag:Hide()
+                end
+                if DJBagsBag then
+                    DJBagsBag:Hide()
+                end
             </OnHide>
         </Scripts>
     </Frame>


### PR DESCRIPTION
## Summary
- Ensure hiding DJBagsBankBar closes DJBagsBank, warband bank, and main bags

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68b38ec109a4832eb1f6cfafd059e3dc