### PR TITLE
Show currency tooltip on bag currency display

### DIFF
--- a/src/bag/Bag.lua
+++ b/src/bag/Bag.lua
@@ -1,5 +1,20 @@
 local ADDON_NAME, ADDON = ...
 
+function DJBagsShowCurrencyTooltip(self)
+    local cnt = C_CurrencyInfo.GetCurrencyListSize()
+    GameTooltip:SetOwner(self, "ANCHOR_NONE")
+    GameTooltip:SetPoint("BOTTOMLEFT", self, "TOPLEFT")
+    GameTooltip:SetText("Currency")
+    for index = 1, cnt do
+        local info = C_CurrencyInfo.GetCurrencyListInfo(index)
+        if info.quantity ~= 0 then
+            local icon = info.iconFileID or info.icon
+            GameTooltip:AddDoubleLine(info.name, info.quantity .. " |T" .. icon .. ":16|t", 1, 1, 1, 1, 1, 1)
+        end
+    end
+    GameTooltip:Show()
+end
+
 local bag = {}
 bag.__index = bag
 

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -174,23 +174,13 @@
                 </Anchors>
                 <Scripts>
                     <OnEnter>
-                        local cnt = C_CurrencyInfo.GetCurrencyListSize()
-                        GameTooltip:SetOwner(self, "ANCHOR_NONE")
-                        GameTooltip:SetPoint("BOTTOMLEFT", self, "TOPLEFT")
-                        GameTooltip:SetText("Currency")
-                        for index = 1, cnt do
-                            local info = C_CurrencyInfo.GetCurrencyListInfo(index)
-                            if info.quantity ~= 0 then
-                                GameTooltip:AddDoubleLine(info.name, info.quantity .. " |T" .. info.iconFileID .. ":16|t", 1, 1, 1, 1, 1, 1)
-                            end
-                        end
-                        GameTooltip:Show()
+                        DJBagsShowCurrencyTooltip(self)
                     </OnEnter>
                     <OnLeave>
-                            GameTooltip:Hide()
+                        GameTooltip:Hide()
                     </OnLeave>
                     <OnMouseDown>
-                            MoneyInputFrame_OpenPopup(self:GetParent().moneyFrame);
+                        MoneyInputFrame_OpenPopup(self:GetParent().moneyFrame)
                     </OnMouseDown>
                 </Scripts>
             </Frame>
@@ -213,7 +203,7 @@
                     <Anchor point="TOPRIGHT" relativeTo="$parent" relativePoint="BOTTOMRIGHT" x="0" y="0"/>
                 </Anchors>
             </Frame>                        
-            <Frame name="$parentCurrency" parentKey="currencyBar" inherits="DJBagsBackgroundTemplate" hidden="true">
+            <Frame name="$parentCurrency" parentKey="currencyBar" inherits="DJBagsBackgroundTemplate" hidden="true" enableMouse="true">
                 <Size x="200" y="33"/>
                 <Anchors>
                     <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="BOTTOMLEFT"/>
@@ -233,6 +223,14 @@
                         </FontString>
                     </Layer>
                 </Layers>
+                <Scripts>
+                    <OnEnter>
+                        DJBagsShowCurrencyTooltip(self)
+                    </OnEnter>
+                    <OnLeave>
+                        GameTooltip:Hide()
+                    </OnLeave>
+                </Scripts>
             </Frame>
             <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
                 <Anchors>


### PR DESCRIPTION
## Summary
- Share currency tooltip logic with a helper function
- Display currency tooltip when hovering over the bag currency bar

## Testing
- `luac -p src/bag/Bag.lua`
- `xmllint --noout src/bag/Bag.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b390ed7108832eaeac1565dc73c25e