### PR TITLE
Anchor currency tooltip to currency bar

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -175,8 +175,10 @@
                 <Scripts>
                     <OnEnter>
                         local cnt = C_CurrencyInfo.GetCurrencyListSize()
-                        GameTooltip:SetOwner(self, "ANCHOR_NONE")
-                        GameTooltip:SetPoint("BOTTOMLEFT", self, "TOPLEFT")
+                        local currencyFrame = self:GetParent():GetParent().currencyBar
+        
+                        GameTooltip:SetOwner(currencyFrame, "ANCHOR_NONE")
+                        GameTooltip:SetPoint("BOTTOMLEFT", currencyFrame, "TOPLEFT")
                         GameTooltip:SetText("Currency")
                         for index = 1, cnt do
                             local info = C_CurrencyInfo.GetCurrencyListInfo(index)


### PR DESCRIPTION
## Summary
- Anchor currency tooltip to the currency bar rather than the gold frame

## Testing
- `xmllint --noout src/bag/Bag.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b392261c54832e85adedfdce17b06d