### PR TITLE
Show currency tooltip when hovering currency bar

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -173,24 +173,6 @@
                     <Anchor point="BOTTOMRIGHT" relativeTo="$parentSearchBox" relativePoint="BOTTOMLEFT"/>
                 </Anchors>
                 <Scripts>
-                    <OnEnter>
-                        local cnt = C_CurrencyInfo.GetCurrencyListSize()
-                        local currencyFrame = self:GetParent():GetParent().currencyBar
-        
-                        GameTooltip:SetOwner(currencyFrame, "ANCHOR_NONE")
-                        GameTooltip:SetPoint("BOTTOMLEFT", currencyFrame, "TOPLEFT")
-                        GameTooltip:SetText("Currency")
-                        for index = 1, cnt do
-                            local info = C_CurrencyInfo.GetCurrencyListInfo(index)
-                            if info.quantity ~= 0 then
-                                GameTooltip:AddDoubleLine(info.name, info.quantity .. " |T" .. info.iconFileID .. ":16|t", 1, 1, 1, 1, 1, 1)
-                            end
-                        end
-                        GameTooltip:Show()
-                    </OnEnter>
-                    <OnLeave>
-                            GameTooltip:Hide()
-                    </OnLeave>
                     <OnMouseDown>
                             MoneyInputFrame_OpenPopup(self:GetParent().moneyFrame);
                     </OnMouseDown>
@@ -235,6 +217,25 @@
                         </FontString>
                     </Layer>
                 </Layers>
+                <Scripts>
+                    <OnEnter>
+                        local cnt = C_CurrencyInfo.GetCurrencyListSize()
+
+                        GameTooltip:SetOwner(self, "ANCHOR_NONE")
+                        GameTooltip:SetPoint("BOTTOMLEFT", self, "TOPLEFT")
+                        GameTooltip:SetText("Currency")
+                        for index = 1, cnt do
+                            local info = C_CurrencyInfo.GetCurrencyListInfo(index)
+                            if info.quantity ~= 0 then
+                                GameTooltip:AddDoubleLine(info.name, info.quantity .. " |T" .. info.iconFileID .. ":16|t", 1, 1, 1, 1, 1, 1)
+                            end
+                        end
+                        GameTooltip:Show()
+                    </OnEnter>
+                    <OnLeave>
+                        GameTooltip:Hide()
+                    </OnLeave>
+                </Scripts>
             </Frame>
             <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
                 <Anchors>


### PR DESCRIPTION
## Summary
- move currency tooltip anchor from gold display to currency bar
- keep gold display click handler for money input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3935470bc832e85954bd2d7b79407