### PR TITLE
Prevent bag icons from highlighting when hovering bank tabs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -217,7 +217,9 @@ function item:OnEnter()
     GameTooltip:Show()
     CursorUpdate(self)
 
-    ADDON.eventManager:Fire('DJBAGS_BAG_HOVER', self.slot, true)
+    if not isBankTabSlot(self.slot) then
+        ADDON.eventManager:Fire('DJBAGS_BAG_HOVER', self.slot, true)
+    end
 end
 
 function item:SetCost(cost)
@@ -234,6 +236,8 @@ end
 function item:OnLeave()
     GameTooltip_Hide()
     ResetCursor()
-    
-    ADDON.eventManager:Fire('DJBAGS_BAG_HOVER', self.slot, false)
+
+    if not isBankTabSlot(self.slot) then
+        ADDON.eventManager:Fire('DJBAGS_BAG_HOVER', self.slot, false)
+    end
 end


### PR DESCRIPTION
## Summary
- avoid emitting hover events for bank tab slots

## Testing
- `luac -p src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b39583f4c4832e9d68eb1597e1519c