### PR TITLE
update bank tab settings api for patch 11.2

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -88,7 +88,12 @@ function item:Update()
         local tabIndex = slot - Enum.BagIndex.CharacterBankTab_1 + 1
 
         -- Determine if this tab has been purchased
-        local purchasedIDs = C_Bank.FetchPurchasedBankTabIDs(Enum.BankType.Character)
+        local purchasedIDs
+        if C_Bank.GetPurchasedBankTabIDs then
+            purchasedIDs = C_Bank.GetPurchasedBankTabIDs(Enum.BankType.Character)
+        elseif C_Bank.FetchPurchasedBankTabIDs then
+            purchasedIDs = C_Bank.FetchPurchasedBankTabIDs(Enum.BankType.Character)
+        end
         local purchased = false
         if purchasedIDs then
             for _, id in ipairs(purchasedIDs) do
@@ -116,7 +121,12 @@ function item:Update()
         if C_Bank then
             -- Newer API builds may expose tab data directly via a helper
             -- function.  Attempt to use it first.
-            if C_Bank.GetBankTabInfo then
+            if C_Bank.GetBankTabDisplayInfo then
+                local info = C_Bank.GetBankTabDisplayInfo(Enum.BankType.Character, tabIndex)
+                if info then
+                    icon = info.icon or info.iconFileID or info.iconTexture
+                end
+            elseif C_Bank.GetBankTabInfo then
                 local info = C_Bank.GetBankTabInfo(Enum.BankType.Character, tabIndex)
                 if info then
                     icon = info.icon or info.iconFileID or info.iconTexture
@@ -125,8 +135,14 @@ function item:Update()
 
             -- If the direct call was unavailable or returned nothing, fall
             -- back to iterating the purchased tab data.
-            if not icon and C_Bank.FetchPurchasedBankTabData then
-                local tabData = C_Bank.FetchPurchasedBankTabData(Enum.BankType.Character)
+            if not icon then
+                local tabData
+                if C_Bank.GetPurchasedBankTabData then
+                    tabData = C_Bank.GetPurchasedBankTabData(Enum.BankType.Character)
+                elseif C_Bank.FetchPurchasedBankTabData then
+                    tabData = C_Bank.FetchPurchasedBankTabData(Enum.BankType.Character)
+                end
+
                 if tabData then
                     local info = tabData[tabIndex] or tabData[slot]
                     if not info then

--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -21,6 +21,15 @@ local function FetchTabInfo(bankType, tabIndex)
         return nil, nil, nil
     end
 
+    if C_Bank.GetBankTabDisplayInfo then
+        local info = C_Bank.GetBankTabDisplayInfo(bankType, tabIndex)
+        if info then
+            local icon = info.icon or info.iconFileID or info.iconTexture
+            local depositFlags = info.depositFlags or info.flags or info.depositFlag
+            return info.name, icon, depositFlags
+        end
+    end
+
     if C_Bank.GetBankTabInfo then
         local info = C_Bank.GetBankTabInfo(bankType, tabIndex)
         if info then
@@ -30,7 +39,26 @@ local function FetchTabInfo(bankType, tabIndex)
         end
     end
 
-    if C_Bank.FetchPurchasedBankTabData then
+    if C_Bank.GetPurchasedBankTabData then
+        local tabData = C_Bank.GetPurchasedBankTabData(bankType)
+        if tabData then
+            local info = tabData[tabIndex]
+            if not info then
+                for _, data in ipairs(tabData) do
+                    local id = data.ID or data.bankTabID
+                    if id == tabIndex then
+                        info = data
+                        break
+                    end
+                end
+            end
+            if info then
+                local icon = info.icon or info.iconFileID or info.iconTexture
+                local depositFlags = info.depositFlags or info.flags or info.depositFlag
+                return info.name, icon, depositFlags
+            end
+        end
+    elseif C_Bank.FetchPurchasedBankTabData then
         local tabData = C_Bank.FetchPurchasedBankTabData(bankType)
         if tabData then
             local info = tabData[tabIndex]


### PR DESCRIPTION
## Summary
- support patch 11.2 bank API for tab settings menu
- refresh bank tab purchase and icon lookups using new API calls

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua src/bagItem/BagItem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b39764afb0832eb25e5271962934e8