### PR TITLE
Handle nil TitleText for bank tab settings

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -31,7 +31,10 @@ local function CreateMenu()
     local frame = CreateFrame("Frame", "DJBagsBankTabSettings", UIParent, "ButtonFrameTemplate")
     frame:Hide()
     frame:SetSize(320, 420)
-    frame.TitleText:SetText(BANK_TAB_SETTINGS or "Bank Tab Settings")
+    local titleText = frame.TitleText or (frame.TitleContainer and frame.TitleContainer.TitleText)
+    if titleText then
+        titleText:SetText(BANK_TAB_SETTINGS or "Bank Tab Settings")
+    end
 
     -- name box
     frame.nameBox = CreateFrame("EditBox", "$parentNameBox", frame, "InputBoxTemplate")


### PR DESCRIPTION
## Summary
- handle absence of `TitleText` on bank tab settings menu

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68b39b72ee78832e92996b8d23a3e009