### PR TITLE
Fix character bank tabs not appearing

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -137,6 +137,10 @@ function bankFrame:UpdateBankType()
         self:UpdateTabSelection(self.bankBag.selectedTab)
     end
 
+    if activeBag and activeBag.BAG_UPDATE_DELAYED then
+        activeBag:BAG_UPDATE_DELAYED()
+    end
+
     self:Show()
 end
 


### PR DESCRIPTION
## Summary
- refresh the active bank bag layout when switching between bank types so character bank tabs show up

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b39ca11a18832e8c1f0e38fafbaf78