### PR TITLE
Use Blizzard bank tab settings menu when available

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -227,9 +227,14 @@ local function CreateSettingsMenu()
 end
 
 function ADDON:GetBankTabSettingsMenu()
+    if BankPanel and BankPanel.TabSettingsMenu then
+        return BankPanel.TabSettingsMenu
+    end
+
     if not self.bankTabSettingsMenu then
         self.bankTabSettingsMenu = CreateSettingsMenu()
     end
+
     return self.bankTabSettingsMenu
 end
 


### PR DESCRIPTION
## Summary
- Prefer Blizzard's `BankPanel.TabSettingsMenu` for bank tab customization if it exists
- Fall back to the addon's custom settings menu when the Blizzard menu is unavailable

## Testing
- `find . -name "*.lua" -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb0e1a68832e9fe4190e9bc52b48