### PR TITLE
Ensure bank tab settings menu anchors to visible bank frame

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -219,7 +219,13 @@ local function CreateSettingsMenu()
         self:Load(bankType, tabIndex)
         self:SetFrameStrata("FULLSCREEN_DIALOG")
         self:ClearAllPoints()
-        self:SetPoint("TOPLEFT", BankFrame, "TOPRIGHT")
+        local anchor = BankFrame
+        if bankType == (Enum.BankType and Enum.BankType.Account) then
+            anchor = DJBagsWarbandBank or anchor
+        else
+            anchor = DJBagsBank or anchor
+        end
+        self:SetPoint("TOPLEFT", anchor, "TOPRIGHT")
         self:Show()
     end
 
@@ -254,7 +260,13 @@ function ADDON:GetBankTabSettingsMenu()
                 self:ClearAllPoints()
             end
             if self.SetPoint then
-                self:SetPoint("TOPLEFT", BankFrame, "TOPRIGHT")
+                local anchor = BankFrame
+                if bankType == (Enum.BankType and Enum.BankType.Account) then
+                    anchor = DJBagsWarbandBank or anchor
+                else
+                    anchor = DJBagsBank or anchor
+                end
+                self:SetPoint("TOPLEFT", anchor, "TOPRIGHT")
             end
             if self.Show then
                 self:Show()


### PR DESCRIPTION
## Summary
- Anchor bank tab settings menu to the appropriate DJBags bank frame instead of the hidden Blizzard `BankFrame`
- Mirror anchor logic in fallback Open helper so menu opens in view

## Testing
- `luacheck src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd64b520832ea4b6e9e5dcc5f6dc