### PR TITLE
Fix bank tab settings menu anchor

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -220,7 +220,7 @@ local function CreateSettingsMenu()
         self:SetFrameStrata("FULLSCREEN_DIALOG")
         self:ClearAllPoints()
         local anchor = BankFrame
-        if bankType == (Enum.BankType and Enum.BankType.Account) then
+        if Enum.BankType and bankType == Enum.BankType.Account then
             anchor = DJBagsWarbandBank or anchor
         else
             anchor = DJBagsBank or anchor
@@ -261,7 +261,7 @@ function ADDON:GetBankTabSettingsMenu()
             end
             if self.SetPoint then
                 local anchor = BankFrame
-                if bankType == (Enum.BankType and Enum.BankType.Account) then
+                if Enum.BankType and bankType == Enum.BankType.Account then
                     anchor = DJBagsWarbandBank or anchor
                 else
                     anchor = DJBagsBank or anchor


### PR DESCRIPTION
## Summary
- ensure bank tab settings menu anchors to character bank when `Enum.BankType` is unavailable

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4beb4b86c832ebe41b3eb28cd8f9c