### PR TITLE
Fix bank tab settings menu not showing

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -249,7 +249,7 @@ function ADDON:GetBankTabSettingsMenu()
     -- existing Open method that anchors to Blizzard's BankPanel.  That frame is
     -- moved off-screen by DJBags, resulting in the menu appearing invisible.
     -- Wrap the menu's Open behavior so the menu is always positioned relative
-    -- to our active bank frame.
+    -- to our active bank frame and parented to a visible frame.
     if menu and not menu.DJBagsWrappedOpen then
         local baseOpen = menu.Open
         function menu:Open(bankType, tabIndex)
@@ -257,6 +257,9 @@ function ADDON:GetBankTabSettingsMenu()
                 baseOpen(self, bankType, tabIndex)
             elseif self.Load then
                 self:Load(bankType, tabIndex)
+            end
+            if self.SetParent then
+                self:SetParent(UIParent)
             end
             if self.SetFrameStrata then
                 self:SetFrameStrata("FULLSCREEN_DIALOG")


### PR DESCRIPTION
## Summary
- reparent bank tab settings menu so it can appear next to DJBags bank frames

## Testing
- `luac -p DJBags/src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4c10e1d98832e8abee1dfa4153290