### PR TITLE
Ensure bank tab settings load icon data

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -243,7 +243,8 @@ function ADDON:GetBankTabSettingsMenu()
         function menu:Open(bankType, tabIndex)
             if baseOpen then
                 baseOpen(self, bankType, tabIndex)
-            elseif self.Load then
+            end
+            if self.Load then
                 self:Load(bankType, tabIndex)
             end
             if self.SetParent then


### PR DESCRIPTION
## Summary
- always call `Load` when opening bank tab settings so icon selection and existing values populate

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7528dc0832e93c418023d6b81e7