### PR TITLE
Fix bank tab settings menu parameter handling

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -58,7 +58,11 @@ function item:Init(id, slot)
             end
 
             local menu = ADDON:GetBankTabSettingsMenu()
-            menu:Open(bankType, tabIndex)
+            if bankType then
+                menu:Open(bankType, tabIndex)
+            else
+                menu:Open(tabIndex)
+            end
 
             PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
             return

--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -264,9 +264,15 @@ function ADDON:GetBankTabSettingsMenu()
     -- to our active bank frame and parented to a visible frame.
     if menu and not menu.DJBagsWrappedOpen then
         local baseOpen = menu.Open
-        function menu:Open(bankType, tabIndex)
+        function menu:Open(...)
+            local bankType, tabIndex
+            if select('#', ...) >= 2 then
+                bankType, tabIndex = ...
+            else
+                tabIndex = ...
+            end
             if baseOpen then
-                baseOpen(self, bankType, tabIndex)
+                baseOpen(self, ...)
             end
             if self.Load then
                 self:Load(bankType, tabIndex)


### PR DESCRIPTION
## Summary
- handle single-argument Open calls for bank tab settings menu
- avoid passing nil bank type when opening bank tab settings

## Testing
- `luac -p src/bagItem/BagItem.lua src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4cca231b8832e9b0144a9553c3b6a