### PR TITLE
Fix bank tab settings icon loading

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -274,9 +274,6 @@ function ADDON:GetBankTabSettingsMenu()
             if baseOpen then
                 baseOpen(self, ...)
             end
-            if self.Load then
-                self:Load(bankType, tabIndex)
-            end
             if self.SetParent then
                 self:SetParent(UIParent)
             end


### PR DESCRIPTION
## Summary
- fix bank tab settings menu so icon picker and existing tab info load correctly

## Testing
- `find src -name '*.lua' -exec luac -p {} +`


------
https://chatgpt.com/codex/tasks/task_e_68b4cddc3134832eb6ca78a14a4521ca