### PR TITLE
Fix bank tab settings menu argument handling

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -272,7 +272,7 @@ function ADDON:GetBankTabSettingsMenu()
                 tabIndex = ...
             end
             if baseOpen then
-                baseOpen(self, ...)
+                baseOpen(self, bankType, tabIndex)
             end
             if self.SetParent then
                 self:SetParent(UIParent)


### PR DESCRIPTION
## Summary
- ensure bank tab settings menu forwards bankType/tabIndex correctly when opening

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4d0456ea4832eaed3922419b2d961