### PR TITLE
Load Blizzard icon selector before showing bank tab settings menu

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -95,6 +95,21 @@ local function FetchTabInfo(bankType, tabIndex)
 end
 
 local function CreateSettingsMenu()
+    -- Ensure the Blizzard icon selector UI is loaded before creating the frame.
+    if C_AddOns and C_AddOns.LoadAddOn then
+        -- Retail clients expose the loader via C_AddOns.
+        pcall(C_AddOns.LoadAddOn, "Blizzard-IconSelector")
+        pcall(C_AddOns.LoadAddOn, "Blizzard_IconSelector")
+    elseif LoadAddOn then
+        -- Fallback for older clients with the global loader.
+        pcall(LoadAddOn, "Blizzard-IconSelector")
+        pcall(LoadAddOn, "Blizzard_IconSelector")
+    elseif UIParentLoadAddOn then
+        -- Final fallback in case UIParentLoadAddOn is available instead.
+        pcall(UIParentLoadAddOn, "Blizzard-IconSelector")
+        pcall(UIParentLoadAddOn, "Blizzard_IconSelector")
+    end
+
     -- Use the generic icon selector template which provides a name edit
     -- box and icon picker.
     local frame = CreateFrame("Frame", "DJBagsBankTabSettingsMenu", UIParent, "IconSelectorPopupFrameTemplate")


### PR DESCRIPTION
## Summary
- Ensure Blizzard's IconSelector addon loads before creating bank tab settings menu
- Fallback to legacy loaders so the icon picker works on older clients

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4d3c57588832e8bfb55ceeda6f7f2