### PR TITLE
Fix character bank tab settings menu missing icons

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -57,7 +57,7 @@ function item:Init(id, slot)
                 bankType = Enum.BankType and Enum.BankType.Character
             end
 
-            local menu = ADDON:GetBankTabSettingsMenu()
+            local menu = ADDON:GetBankTabSettingsMenu(bankType)
             if bankType then
                 menu:Open(bankType, tabIndex)
             else

--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -28,8 +28,9 @@ function DJBagsBankTabButton_OnLoad(self, tabIndex)
 
     self:SetScript("OnClick", function(btn, which)
         if which == "RightButton" then
-            local menu = ADDON:GetBankTabSettingsMenu()
-            menu:Open(Enum.BankType and Enum.BankType.Character, tabIndex)
+            local bankType = Enum.BankType and Enum.BankType.Character
+            local menu = ADDON:GetBankTabSettingsMenu(bankType)
+            menu:Open(bankType, tabIndex)
             PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
         else
             if DJBagsBankBar and DJBagsBankBar.bankBag and DJBagsBankBar.bankBag.SelectTab then

--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -259,10 +259,19 @@ local function CreateSettingsMenu()
     return frame
 end
 
-function ADDON:GetBankTabSettingsMenu()
+function ADDON:GetBankTabSettingsMenu(bankType)
     local menu
 
-    if BankPanel and BankPanel.TabSettingsMenu then
+    -- Prefer our custom settings menu for character bank tabs so the
+    -- icon selector is always initialized correctly.  Fall back to the
+    -- Blizzard implementation for other bank types so features like
+    -- deposit restrictions remain available.
+    local useCustom = true
+    if bankType and Enum.BankType and bankType ~= Enum.BankType.Character then
+        useCustom = false
+    end
+
+    if not useCustom and BankPanel and BankPanel.TabSettingsMenu then
         menu = BankPanel.TabSettingsMenu
     else
         if not self.bankTabSettingsMenu then


### PR DESCRIPTION
## Summary
- use custom settings menu for character bank tabs to ensure icon selector initializes
- pass bank type when opening tab settings so icons and names load and save correctly

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6987428832ea67cb3a38fdb4402