### PR TITLE
Fix character bank tab settings menu

### DIFF
--- a/src/bank/BankTabSettingsMenu.lua
+++ b/src/bank/BankTabSettingsMenu.lua
@@ -388,10 +388,10 @@ function ADDON:GetBankTabSettingsMenu(bankType)
 
     -- Prefer our custom settings menu for character bank tabs so the
     -- icon selector is always initialized correctly.  Fall back to the
-    -- Blizzard implementation for other bank types so features like
+    -- Blizzard implementation only for account banks so features like
     -- deposit restrictions remain available.
     local useCustom = true
-    if bankType and Enum.BankType and bankType ~= Enum.BankType.Character then
+    if bankType and Enum.BankType and bankType == Enum.BankType.Account then
         useCustom = false
     end
 


### PR DESCRIPTION
## Summary
- ensure character bank tabs use custom settings menu instead of Blizzard menu

## Testing
- `luac -p src/bank/BankTabSettingsMenu.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4de1f53bc832ebec5ca0d52062a94