### PR TITLE
Add warband bank tab support

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -33,6 +33,25 @@ function DJBagsBankTabButton_OnLoad(self, tabIndex)
     end)
 end
 
+-- Helper to initialize a warband bank tab button for a specific tab index.
+function DJBagsAccountBankTabButton_OnLoad(self, tabIndex)
+    local slot = Enum.BagIndex and Enum.BagIndex.AccountBankTab_1 and (Enum.BagIndex.AccountBankTab_1 + tabIndex - 1)
+    if slot then
+        local id = C_Container and C_Container.ContainerIDToInventoryID and C_Container.ContainerIDToInventoryID(slot)
+        DJBagsBagItemLoad(self, slot, id)
+    end
+
+    -- Disable drag interactions; tabs are for selection only.
+    self:SetScript('OnDragStart', nil)
+    self:SetScript('OnReceiveDrag', nil)
+
+    self:SetScript("OnClick", function()
+        if DJBagsBankBar and DJBagsBankBar.warbandBankBag and DJBagsBankBar.warbandBankBag.SelectTab then
+            DJBagsBankBar.warbandBankBag:SelectTab(tabIndex)
+        end
+    end)
+end
+
 function DJBagsHideBlizzardBank()
     BankFrame:SetAlpha(0)
     BankFrame:EnableMouse(false)

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -189,6 +189,72 @@
                     </OnLoad>
                 </Scripts>
             </ItemButton>
+            <ItemButton name="$parentAccountBag1" parentKey="accountBag1">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="DJBagsWarbandBank" relativePoint="TOPRIGHT" x="5" y="0"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 1)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag2" parentKey="accountBag2">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag1" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 2)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag3" parentKey="accountBag3">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag2" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 3)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag4" parentKey="accountBag4">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag3" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 4)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag5" parentKey="accountBag5">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag4" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 5)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
+            <ItemButton name="$parentAccountBag6" parentKey="accountBag6">
+                <Size x="36" y="36"/>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="$parentAccountBag5" relativePoint="BOTTOMLEFT" y="-5"/>
+                </Anchors>
+                <Scripts>
+                    <OnLoad>
+                        DJBagsAccountBankTabButton_OnLoad(self, 6)
+                    </OnLoad>
+                </Scripts>
+            </ItemButton>
             <Button name="$parentClose" parentKey="close" inherits="UIPanelCloseButton">
                 <Anchors>
                     <Anchor point="CENTER" relativePoint="TOPRIGHT" x="-2" y="-2"/>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -171,11 +171,16 @@ function bankFrame:BANKFRAME_CLOSED()
 end
 
 function bankFrame:UpdateTabSelection(selected)
+    local bankType = BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
+    local isCharacterBank = not bankType or bankType == Enum.BankType.Character
+
     if self.allTab then
-        self.allTab:SetAlpha(selected == 0 and 1 or 0.4)
+        self.allTab:SetAlpha(isCharacterBank and selected == 0 and 1 or 0.4)
     end
+
     for i = 1, 6 do
-        local btn = self['bag' .. i]
+        local key = (isCharacterBank and 'bag' or 'accountBag') .. i
+        local btn = self[key]
         if btn then
             btn:SetAlpha(selected == i and 1 or 0.4)
         end


### PR DESCRIPTION
## Summary
- add tab button helper for warband bank slots
- render warband tab buttons and update selection highlight

## Testing
- `luac -p src/bank/Bank.lua`
- `luac -p src/bank/BankFrame.lua`
- `xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b640ce1a04832e9e9e1e53754d2550