### PR TITLE
Hide unpurchased warband bank tabs

### DIFF
--- a/src/bagItem/BagItem.lua
+++ b/src/bagItem/BagItem.lua
@@ -62,6 +62,11 @@ function item:Update()
         isCharacterBankTab = slot >= Enum.BagIndex.CharacterBankTab_1 and slot <= Enum.BagIndex.CharacterBankTab_6
     end
 
+    local isAccountBankTab = false
+    if Enum.BagIndex.AccountBankTab_1 and Enum.BagIndex.AccountBankTab_6 then
+        isAccountBankTab = slot >= Enum.BagIndex.AccountBankTab_1 and slot <= Enum.BagIndex.AccountBankTab_6
+    end
+
     if C_Bank and isCharacterBankTab then
         local tabIndex = slot - Enum.BagIndex.CharacterBankTab_1 + 1
 
@@ -119,6 +124,104 @@ function item:Update()
                     tabData = C_Bank.GetPurchasedBankTabData(Enum.BankType.Character)
                 elseif C_Bank.FetchPurchasedBankTabData then
                     tabData = C_Bank.FetchPurchasedBankTabData(Enum.BankType.Character)
+                end
+
+                if tabData then
+                    local info = tabData[tabIndex] or tabData[slot]
+                    if not info then
+                        for _, data in ipairs(tabData) do
+                            local infoID = data.ID or data.bankTabID
+                            if infoID == tabIndex or infoID == slot then
+                                info = data
+                                break
+                            end
+                        end
+                    end
+                    if info then
+                        icon = info.icon or info.iconFileID or info.iconTexture
+                    end
+                end
+            end
+        end
+
+        -- As a final fallback, use the icon of the item placed in the bank
+        -- tab slot if one exists.
+        if not icon then
+            icon = GetInventoryItemTexture("player", self:GetID())
+        end
+
+        if icon then
+            SetItemButtonTexture(self, icon)
+        end
+
+        local slotcount = C_Container.GetContainerNumSlots(slot)
+        if slotcount > 0 then
+            self.Count:SetText(tostring(slotcount))
+            self.Count:Show()
+        else
+            self.Count:Hide()
+        end
+        self.buy = nil
+        return
+    end
+
+    if C_Bank and isAccountBankTab then
+        local tabIndex = slot - Enum.BagIndex.AccountBankTab_1 + 1
+
+        -- Determine if this tab has been purchased
+        local purchasedIDs
+        if C_Bank.GetPurchasedBankTabIDs then
+            purchasedIDs = C_Bank.GetPurchasedBankTabIDs(Enum.BankType.Account)
+        elseif C_Bank.FetchPurchasedBankTabIDs then
+            purchasedIDs = C_Bank.FetchPurchasedBankTabIDs(Enum.BankType.Account)
+        end
+        local purchased = false
+        if purchasedIDs then
+            for _, id in ipairs(purchasedIDs) do
+                if id == tabIndex or id == slot then
+                    purchased = true
+                    break
+                end
+            end
+        end
+
+        if not purchased then
+            self:Hide()
+            self.buy = nil
+            return
+        end
+
+        self:Show()
+
+        -- Tab is purchased, fetch its icon from the bank data.  The icon
+        -- chosen for a bank tab is not tied to the inventory item placed in
+        -- the slot, so prefer the information returned by the C_Bank API and
+        -- only fall back to the inventory texture as a last resort.
+        local icon
+
+        if C_Bank then
+            -- Newer API builds may expose tab data directly via a helper
+            -- function.  Attempt to use it first.
+            if C_Bank.GetBankTabDisplayInfo then
+                local info = C_Bank.GetBankTabDisplayInfo(Enum.BankType.Account, tabIndex)
+                if info then
+                    icon = info.icon or info.iconFileID or info.iconTexture
+                end
+            elseif C_Bank.GetBankTabInfo then
+                local info = C_Bank.GetBankTabInfo(Enum.BankType.Account, tabIndex)
+                if info then
+                    icon = info.icon or info.iconFileID or info.iconTexture
+                end
+            end
+
+            -- If the direct call was unavailable or returned nothing, fall
+            -- back to iterating the purchased tab data.
+            if not icon then
+                local tabData
+                if C_Bank.GetPurchasedBankTabData then
+                    tabData = C_Bank.GetPurchasedBankTabData(Enum.BankType.Account)
+                elseif C_Bank.FetchPurchasedBankTabData then
+                    tabData = C_Bank.FetchPurchasedBankTabData(Enum.BankType.Account)
                 end
 
                 if tabData then


### PR DESCRIPTION
## Summary
- Avoid showing account/warband bank tabs that haven't been purchased
- Reuse existing C_Bank icon lookups for purchased account tabs

## Testing
- `luacheck src/bagItem/BagItem.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b79babb4e0832eb5fc8d3610676f11