### PR TITLE
Fix warband bank showing locked tabs

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -155,6 +155,13 @@ function bankFrame:UpdateBankType()
         self:UpdateTabSelection(self.bankBag.selectedTab)
     end
 
+    if self.bankBag then
+        self.bankBag:BAG_UPDATE_DELAYED()
+    end
+    if self.warbandBankBag then
+        self.warbandBankBag:BAG_UPDATE_DELAYED()
+    end
+
     self:Show()
 end
 


### PR DESCRIPTION
## Summary
- Refresh both character and warband bank frames when switching tabs so locked warband tabs no longer remain visible.

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68b79e2247c0832e9a8d6d112515c9a4