### PR TITLE
Hide locked Warbank tabs

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -91,7 +91,13 @@ function bankFrame:UpdateBankType()
         for i = 1, 6 do
             local bag = self['bag' .. i]
             local acc = self['accountBag' .. i]
-            if bag then bag:Show() end
+            if bag then
+                if bag.Update then
+                    bag:Update()
+                else
+                    bag:Show()
+                end
+            end
             if acc then acc:Hide() end
         end
     else
@@ -102,7 +108,13 @@ function bankFrame:UpdateBankType()
             local bag = self['bag' .. i]
             local acc = self['accountBag' .. i]
             if bag then bag:Hide() end
-            if acc then acc:Show() end
+            if acc then
+                if acc.Update then
+                    acc:Update()
+                else
+                    acc:Show()
+                end
+            end
         end
     end
 


### PR DESCRIPTION
## Summary
- Avoid showing Warband bank tabs that haven't been purchased by updating each tab's visibility instead of force-showing them

## Testing
- `luacheck src` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb00c0cee8832e9eb24cfc64d9f6e5