### PR TITLE
Handle warband bank tab unlock events

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -83,6 +83,10 @@ function DJBagsRegisterBankBagContainer(self, bags, bankType)
     ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
     ADDON.eventManager:Add('PLAYERBANKSLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERBANKBAGSLOTS_CHANGED', self)
+    -- Warband bank tabs use separate events when purchased. Ensure we listen
+    -- for those so newly unlocked tabs become visible without a reload.
+    ADDON.eventManager:Add('ACCOUNT_BANK_TAB_PURCHASED', self)
+    ADDON.eventManager:Add('PLAYERACCOUNTBANKSLOTS_CHANGED', self)
 
     BankFrame:UnregisterAllEvents()
     BankFrame:SetScript('OnShow', DJBagsHideBlizzardBank)
@@ -213,6 +217,18 @@ function bank:BAG_UPDATE_DELAYED()
 end
 
 function bank:PLAYERBANKBAGSLOTS_CHANGED()
+    if self.isActive then
+        self:BAG_UPDATE_DELAYED()
+    end
+end
+
+function bank:ACCOUNT_BANK_TAB_PURCHASED()
+    if self.isActive then
+        self:BAG_UPDATE_DELAYED()
+    end
+end
+
+function bank:PLAYERACCOUNTBANKSLOTS_CHANGED()
     if self.isActive then
         self:BAG_UPDATE_DELAYED()
     end


### PR DESCRIPTION
## Summary
- Ensure newly purchased warband bank tabs appear without reloading by listening for account bank events

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb024c28dc832e860986c968b2a7ca