### PR TITLE
Display purchased warband bank tabs

### DIFF
--- a/src/bank/Bank.lua
+++ b/src/bank/Bank.lua
@@ -86,6 +86,7 @@ function DJBagsRegisterBankBagContainer(self, bags, bankType)
     -- Warband bank tabs use separate events when purchased. Ensure we listen
     -- for those so newly unlocked tabs become visible without a reload.
     ADDON.eventManager:Add('ACCOUNT_BANK_TAB_PURCHASED', self)
+    ADDON.eventManager:Add('ACCOUNT_BANK_SLOTS_CHANGED', self)
     ADDON.eventManager:Add('PLAYERACCOUNTBANKSLOTS_CHANGED', self)
 
     BankFrame:UnregisterAllEvents()
@@ -228,11 +229,13 @@ function bank:ACCOUNT_BANK_TAB_PURCHASED()
     end
 end
 
-function bank:PLAYERACCOUNTBANKSLOTS_CHANGED()
+function bank:ACCOUNT_BANK_SLOTS_CHANGED()
     if self.isActive then
         self:BAG_UPDATE_DELAYED()
     end
 end
+
+bank.PLAYERACCOUNTBANKSLOTS_CHANGED = bank.ACCOUNT_BANK_SLOTS_CHANGED
 
 -- Override the bag hover event to prevent highlighting items when hovering
 -- over bank tabs.  Tab selection already filters the visible items.


### PR DESCRIPTION
## Summary
- Ensure warband bank listens for all slot purchase events so newly bought tabs appear without a reload

## Testing
- `luac -p src/bank/Bank.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb03cbd804832e9ce006798017beaa