### PR TITLE
Fix warband bank tab selection refresh

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -163,8 +163,9 @@ function bankFrame:UpdateBankType()
     end
     PanelTemplates_ResizeTabsToFit(self, maxWidth)
 
-    if isCharacterBank and self.bankBag and self.bankBag.selectedTab then
-        self:UpdateTabSelection(self.bankBag.selectedTab)
+    local activeContainer = isCharacterBank and self.bankBag or self.warbandBankBag
+    if activeContainer and activeContainer.selectedTab then
+        self:UpdateTabSelection(activeContainer.selectedTab)
     end
 
     if self.bankBag then


### PR DESCRIPTION
## Summary
- Ensure bank bar updates active container tab selection for both character and warband banks

## Testing
- `luac -p src/bank/BankFrame.lua`

------
https://chatgpt.com/codex/tasks/task_e_68bb057d0f98832ea505202fea98b100