### PR TITLE
Remove character and warband bank tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A bag addon that sorts items into categories defined by Blizzard or user specifi
 * PAWN Support.
 * Clear new items with the clear items button next to search bar. ~~or by mousing over them.~~
 * Restack items: Restack items for bags with the restack button.
-* Switch between character and warband banks via tabs.
 * All bags settings for columns and categories.
 * User defined settings for all chars or per char: press ALT + Left mouse button on an item to open dialogue.
 * Clear a single new item: ALT + Right mouse button on new item to remove it from new items list.

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -300,56 +300,6 @@
                     </OnLoad>
                 </Scripts>
             </Frame>
-            <Button name="$parentTab1" parentKey="characterTab" inherits="PanelTabButtonTemplate" id="1">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="DJBagsBank" relativePoint="BOTTOMLEFT" x="2" y="2"/>
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        self:SetText(CHARACTER)
-                        if not self.Text and self.GetFontString then
-                            self.Text = self:GetFontString()
-                        end
-                        if not self.Left and self.LeftDisabled then
-                            self.Left = self.LeftDisabled
-                            self.Middle = self.MiddleDisabled
-                            self.Right = self.RightDisabled
-                        end
-                        if self.Left then
-                            PanelTemplates_TabResize(self, 0)
-                        end
-                    </OnLoad>
-                    <OnClick>
-                        PanelTemplates_SetTab(self:GetParent(), 1)
-                        BankFrame:SetTab(1, Enum.BankType and Enum.BankType.Character)
-                    </OnClick>
-                </Scripts>
-            </Button>
-            <Button name="$parentTab2" parentKey="warbandTab" inherits="PanelTabButtonTemplate" id="2">
-                <Anchors>
-                    <Anchor point="LEFT" relativeTo="$parentTab1" relativePoint="RIGHT" x="-16"/>
-                </Anchors>
-                <Scripts>
-                    <OnLoad>
-                        self:SetText(WARBAND_BANK or "Warband")
-                        if not self.Text and self.GetFontString then
-                            self.Text = self:GetFontString()
-                        end
-                        if not self.Left and self.LeftDisabled then
-                            self.Left = self.LeftDisabled
-                            self.Middle = self.MiddleDisabled
-                            self.Right = self.RightDisabled
-                        end
-                        if self.Left then
-                            PanelTemplates_TabResize(self, 0)
-                        end
-                    </OnLoad>
-                    <OnClick>
-                        PanelTemplates_SetTab(self:GetParent(), 2)
-                        BankFrame:SetTab(2, Enum.BankType and Enum.BankType.Account)
-                    </OnClick>
-                </Scripts>
-            </Button>
         </Frames>
         <Scripts>
             <OnLoad>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -56,15 +56,6 @@ function DJBagsRegisterBankFrame(self, bags)
         self:SetUserPlaced(false)
     end
 
-    PanelTemplates_SetNumTabs(self, 2)
-
-    -- Defer selecting the initial tab until the next frame so that the
-    -- child tab buttons have finished running their own OnLoad scripts and
-    -- created the textures expected by PanelTemplates_SelectTab.
-    C_Timer.After(0, function()
-        PanelTemplates_SetTab(self, 1)
-    end)
-
     -- Update our visibility when the bank switches between character and account tabs.
     hooksecurefunc(BankFrame, "SetTab", function()
         self:UpdateBankType()
@@ -126,42 +117,20 @@ function bankFrame:UpdateBankType()
     if activeBag then
         self:ClearAllPoints()
         self:SetPoint("TOPRIGHT", activeBag, "BOTTOMRIGHT", 0, -5)
-        if self.characterTab then
-            self.characterTab:ClearAllPoints()
-            self.characterTab:SetPoint("TOPLEFT", activeBag, "BOTTOMLEFT", 2, 2)
-        end
 
         if self.settingsBtn and self.restackButton and self.search then
             local padding = 18
             local spacing = 3
 
-            -- Minimum width should accommodate the search box and the
-            -- character/warband tabs. Include a bit of extra padding so the
-            -- tabs are fully visible.
-            local searchWidth = self.settingsBtn:GetWidth() + self.restackButton:GetWidth() + self.search:GetWidth() + padding + spacing * 2
-            local tabWidth = 0
-            if self.characterTab and self.warbandTab then
-                tabWidth = self.characterTab:GetWidth() + self.warbandTab:GetWidth() + padding
-            end
-            local width = math.max(searchWidth, tabWidth)
+            -- Minimum width should accommodate the search box.
+            local width = self.settingsBtn:GetWidth() + self.restackButton:GetWidth() + self.search:GetWidth() + padding + spacing * 2
 
-            -- Height must be at least tall enough for the tabs.
-            local searchHeight = self.search:GetHeight() + padding
-            local tabHeight = self.characterTab and (self.characterTab:GetHeight() + padding) or 0
-            local height = math.max(searchHeight, tabHeight)
+            -- Height only needs to fit the search box.
+            local height = self.search:GetHeight() + padding
 
             self:SetSize(width, height)
         end
     end
-
-    PanelTemplates_SetTab(self, isCharacterBank and 1 or 2)
-    -- Ensure tabs resize using at least our minimum width so the frame does
-    -- not shrink when switching tabs.
-    local maxWidth = (activeBag and activeBag:GetWidth()) or 0
-    if self:GetWidth() > maxWidth then
-        maxWidth = self:GetWidth()
-    end
-    PanelTemplates_ResizeTabsToFit(self, maxWidth)
 
     local activeContainer = isCharacterBank and self.bankBag or self.warbandBankBag
     if activeContainer and activeContainer.selectedTab then


### PR DESCRIPTION
## Summary
- hide Character and Warband bank tab buttons
- simplify bank frame layout to exclude tab handling
- update README to reflect removal of bank tabs

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b7c9924832e8360a7b46a3c04ef