### PR TITLE
Show reagent deposit button when bank is unlocked

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -97,7 +97,7 @@ function bankFrame:UpdateBankType()
     end
 
     if self.depositButton then
-        local showDeposit = isCharacterBank and IsReagentBankUnlocked and IsReagentBankUnlocked()
+        local showDeposit = isCharacterBank and (not IsReagentBankUnlocked or IsReagentBankUnlocked())
         self.depositButton:SetShown(showDeposit)
     end
 


### PR DESCRIPTION
## Summary
- Ensure deposit button remains visible when reagent bank is available

## Testing
- `luac -p src/bank/BankFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bb121c9bcc832ea3b6a2c2e08a48be