### PR TITLE
Fix deposit reagent button for patch 11.2

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -111,25 +111,10 @@
                 <Anchors>
                     <Anchor point="RIGHT" relativeTo="$parentRestackButton" relativePoint="LEFT" x="-3"/>
                 </Anchors>
+                <NormalTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
+                <PushedTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
+                <HighlightTexture file="Interface\\Buttons\\UI-Common-MouseHilight" alphaMode="ADD"/>
                 <Scripts>
-                    <OnLoad>
-                        self:RegisterEvent("ADDON_LOADED")
-                        self:RegisterEvent("BANKFRAME_OPENED")
-                        self:SetScript("OnEvent", function(button, event, addon)
-                            if event == "ADDON_LOADED" and addon ~= "Blizzard_BankUI" then return end
-                            local default = ReagentBankFrame and ReagentBankFrame.DepositButton
-                            if default and default:GetNormalTexture() then
-                                button:SetNormalTexture(default:GetNormalTexture():GetTexture())
-                                button:SetPushedTexture(default:GetPushedTexture():GetTexture())
-                                local highlight = default:GetHighlightTexture()
-                                if highlight then
-                                    button:SetHighlightTexture(highlight:GetTexture(), "ADD")
-                                end
-                                button:UnregisterEvent("ADDON_LOADED")
-                                button:UnregisterEvent("BANKFRAME_OPENED")
-                            end
-                        end)
-                    </OnLoad>
                     <OnEnter>
                         GameTooltip:SetOwner(self, 'TOPRIGHT')
                         GameTooltip:SetText(REAGENTBANK_DEPOSIT or "Deposit Reagents")
@@ -139,8 +124,14 @@
                         GameTooltip:Hide()
                     </OnLeave>
                     <OnClick>
-                        if DepositReagentBank then
+                        if C_Bank and C_Bank.DepositAllReagents then
+                            C_Bank.DepositAllReagents()
+                        elseif C_Container and C_Container.DepositAllReagents then
+                            C_Container.DepositAllReagents()
+                        elseif DepositReagentBank then
                             DepositReagentBank()
+                        elseif DepositAllReagents then
+                            DepositAllReagents()
                         end
                     </OnClick>
                 </Scripts>

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -97,7 +97,8 @@ function bankFrame:UpdateBankType()
     end
 
     if self.depositButton then
-        local showDeposit = isCharacterBank and (not IsReagentBankUnlocked or IsReagentBankUnlocked())
+        local IsReagentBankUnlockedFunc = (C_Bank and C_Bank.IsReagentBankUnlocked) or IsReagentBankUnlocked
+        local showDeposit = isCharacterBank and (not IsReagentBankUnlockedFunc or IsReagentBankUnlockedFunc())
         self.depositButton:SetShown(showDeposit)
     end
 


### PR DESCRIPTION
## Summary
- ensure deposit reagents button uses new 11.2 APIs
- show deposit button with static textures instead of copying Blizzard's button

## Testing
- `find src -name '*.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68bb130a540c832ea959511f7858a213