### PR TITLE
Ensure deposit reagents button is always visible

### DIFF
--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -97,9 +97,11 @@ function bankFrame:UpdateBankType()
     end
 
     if self.depositButton then
-        local IsReagentBankUnlockedFunc = (C_Bank and C_Bank.IsReagentBankUnlocked) or IsReagentBankUnlocked
-        local showDeposit = isCharacterBank and (not IsReagentBankUnlockedFunc or IsReagentBankUnlockedFunc())
-        self.depositButton:SetShown(showDeposit)
+        local hasDeposit = (C_Bank and C_Bank.DepositAllReagents)
+            or (C_Container and C_Container.DepositAllReagents)
+            or DepositReagentBank
+            or DepositAllReagents
+        self.depositButton:SetShown(hasDeposit)
     end
 
     local activeBag = isCharacterBank and self.bankBag or self.warbandBankBag


### PR DESCRIPTION
## Summary
- show the deposit-all-reagents button whenever a deposit API exists

## Testing
- `luacheck src/bank/BankFrame.lua`
- `luacheck src`

------
https://chatgpt.com/codex/tasks/task_e_68bb14d1c72c832e8f884e4d539ceb9e