### PR TITLE
Add custom deposit reagent button

### DIFF
--- a/src/bag/Bag.lua
+++ b/src/bag/Bag.lua
@@ -15,6 +15,8 @@ function DJBagsRegisterBagBagContainer(self, bags)
 
     ADDON.eventManager:Add("NewItemCleared", self)
     ADDON.eventManager:Add("CURRENCY_DISPLAY_UPDATE", self)
+    ADDON.eventManager:Add('BANKFRAME_OPENED', self)
+    ADDON.eventManager:Add('BANKFRAME_CLOSED', self)
 
     self:UpdateCurrency()
 end
@@ -98,4 +100,20 @@ end
 
 function bag:CURRENCY_DISPLAY_UPDATE()
     self:UpdateCurrency()
+end
+
+function bag:BANKFRAME_OPENED()
+    if self.mainBar and self.mainBar.depositButton and self.mainBar.clearButton then
+        self.mainBar.depositButton:Show()
+        self.mainBar.clearButton:ClearAllPoints()
+        self.mainBar.clearButton:SetPoint("RIGHT", self.mainBar.depositButton, "LEFT", -3, 0)
+    end
+end
+
+function bag:BANKFRAME_CLOSED()
+    if self.mainBar and self.mainBar.depositButton and self.mainBar.clearButton and self.mainBar.restackButton then
+        self.mainBar.depositButton:Hide()
+        self.mainBar.clearButton:ClearAllPoints()
+        self.mainBar.clearButton:SetPoint("RIGHT", self.mainBar.restackButton, "LEFT", -3, 0)
+    end
 end

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -100,7 +100,7 @@
                     </OnClick>
                 </Scripts>
             </CheckButton>
-            <Button name="$parentRestackBtn">
+            <Button name="$parentRestackBtn" parentKey="restackButton">
                 <Size x="16" y="16"/>
                 <Anchors>
                     <Anchor point="RIGHT" relativeTo="$parentBagBtn" relativePoint="LEFT" x="-3"/>
@@ -122,7 +122,37 @@
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentClearButton">
+            <Button name="$parentDepositButton" parentKey="depositButton" hidden="true">
+                <Size x="16" y="16"/>
+                <Anchors>
+                    <Anchor point="RIGHT" relativeTo="$parentRestackBtn" relativePoint="LEFT" x="-3"/>
+                </Anchors>
+                <NormalTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
+                <PushedTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
+                <HighlightTexture file="Interface\\Buttons\\UI-Common-MouseHilight" alphaMode="ADD"/>
+                <Scripts>
+                    <OnEnter>
+                        GameTooltip:SetOwner(self, 'TOPRIGHT')
+                        GameTooltip:SetText(REAGENTBANK_DEPOSIT or "Deposit Reagents")
+                        GameTooltip:Show()
+                    </OnEnter>
+                    <OnLeave>
+                        GameTooltip:Hide()
+                    </OnLeave>
+                    <OnClick>
+                        if C_Bank and C_Bank.DepositAllReagents then
+                            C_Bank.DepositAllReagents()
+                        elseif C_Container and C_Container.DepositAllReagents then
+                            C_Container.DepositAllReagents()
+                        elseif DepositReagentBank then
+                            DepositReagentBank()
+                        elseif DepositAllReagents then
+                            DepositAllReagents()
+                        end
+                    </OnClick>
+                </Scripts>
+            </Button>
+            <Button name="$parentClearButton" parentKey="clearButton">
                 <Size x="25" y="25"/>
                 <Anchors>
                     <Anchor point="RIGHT" relativeTo="$parentRestackBtn" relativePoint="LEFT" x="-3"/>


### PR DESCRIPTION
## Summary
- add a standalone "Deposit Reagents" button to the main bag bar
- show the button only while the bank is open and wire it to Blizzard's deposit APIs

## Testing
- `luac -p src/bag/Bag.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bb183a9e0c832eb6683e1971f505bb