### PR TITLE
Fix missing deposit reagents icon

### DIFF
--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -127,9 +127,9 @@
                 <Anchors>
                     <Anchor point="RIGHT" relativeTo="$parentRestackBtn" relativePoint="LEFT" x="-3"/>
                 </Anchors>
-                <NormalTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
-                <PushedTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
-                <HighlightTexture file="Interface\\Buttons\\UI-Common-MouseHilight" alphaMode="ADD"/>
+                <NormalTexture file="Interface\Icons\INV_Misc_Bag_08"/>
+                <PushedTexture file="Interface\Icons\INV_Misc_Bag_08"/>
+                <HighlightTexture file="Interface\Buttons\UI-Common-MouseHilight" alphaMode="ADD"/>
                 <Scripts>
                     <OnEnter>
                         GameTooltip:SetOwner(self, 'TOPRIGHT')

--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -111,9 +111,9 @@
                 <Anchors>
                     <Anchor point="RIGHT" relativeTo="$parentRestackButton" relativePoint="LEFT" x="-3"/>
                 </Anchors>
-                <NormalTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
-                <PushedTexture file="Interface\\Icons\\INV_Misc_Bag_08"/>
-                <HighlightTexture file="Interface\\Buttons\\UI-Common-MouseHilight" alphaMode="ADD"/>
+                <NormalTexture file="Interface\Icons\INV_Misc_Bag_08"/>
+                <PushedTexture file="Interface\Icons\INV_Misc_Bag_08"/>
+                <HighlightTexture file="Interface\Buttons\UI-Common-MouseHilight" alphaMode="ADD"/>
                 <Scripts>
                     <OnEnter>
                         GameTooltip:SetOwner(self, 'TOPRIGHT')


### PR DESCRIPTION
## Summary
- fix deposit all reagents button not displaying by correcting texture paths

## Testing
- `xmllint --noout src/bank/Bank.xml src/bag/Bag.xml`

------
https://chatgpt.com/codex/tasks/task_e_68be2e54b038832ea844e5eb99dccc08