### PR TITLE
Ensure toasts open DJBags

### DIFF
--- a/src/DJBags.lua
+++ b/src/DJBags.lua
@@ -62,6 +62,24 @@ ToggleBackpack = function()
     end
 end
 
+local oldOpen = OpenBag
+OpenBag = function(id)
+    if id < 5 and id > -1 then
+        DJBagsBag:Show()
+    else
+        oldOpen(id)
+    end
+end
+
+local oldClose = CloseBag
+CloseBag = function(id)
+    if id < 5 and id > -1 then
+        DJBagsBag:Hide()
+    else
+        oldClose(id)
+    end
+end
+
 OpenAllBags = function()
     DJBagsBag:Show()
 end


### PR DESCRIPTION
## Summary
- Handle OpenBag and CloseBag so that clicks from UI toasts show the DJBags window instead of Blizzard bags

## Testing
- `luac -p src/DJBags.lua`

------
https://chatgpt.com/codex/tasks/task_e_68bf91bcab70832eb75ce87532587691