### PR TITLE
Limit reagent deposit button to bank bar

### DIFF
--- a/src/bag/Bag.lua
+++ b/src/bag/Bag.lua
@@ -104,18 +104,8 @@ end
 
 function bag:BANKFRAME_OPENED()
     self:Show()
-    if self.mainBar and self.mainBar.depositButton and self.mainBar.clearButton then
-        self.mainBar.depositButton:Show()
-        self.mainBar.clearButton:ClearAllPoints()
-        self.mainBar.clearButton:SetPoint("RIGHT", self.mainBar.depositButton, "LEFT", -3, 0)
-    end
 end
 
 function bag:BANKFRAME_CLOSED()
     self:Hide()
-    if self.mainBar and self.mainBar.depositButton and self.mainBar.clearButton and self.mainBar.restackButton then
-        self.mainBar.depositButton:Hide()
-        self.mainBar.clearButton:ClearAllPoints()
-        self.mainBar.clearButton:SetPoint("RIGHT", self.mainBar.restackButton, "LEFT", -3, 0)
-    end
 end

--- a/src/bag/Bag.xml
+++ b/src/bag/Bag.xml
@@ -122,38 +122,6 @@
                     </OnClick>
                 </Scripts>
             </Button>
-            <Button name="$parentDepositButton" parentKey="depositButton" hidden="true">
-                <Size x="16" y="16"/>
-                <Anchors>
-                    <Anchor point="RIGHT" relativeTo="$parentRestackBtn" relativePoint="LEFT" x="-3"/>
-                </Anchors>
-                <NormalTexture file="Interface\Icons\INV_Misc_Bag_08"/>
-                <PushedTexture file="Interface\Icons\INV_Misc_Bag_08"/>
-                <HighlightTexture file="Interface\Buttons\UI-Common-MouseHilight" alphaMode="ADD"/>
-                <Scripts>
-                    <OnEnter>
-                        GameTooltip:SetOwner(self, 'TOPRIGHT')
-                        GameTooltip:SetText(REAGENTBANK_DEPOSIT or "Deposit Reagents")
-                        GameTooltip:Show()
-                    </OnEnter>
-                    <OnLeave>
-                        GameTooltip:Hide()
-                    </OnLeave>
-                    <OnClick>
-                        if C_Bank and C_Bank.DepositAllReagents then
-                            C_Bank.DepositAllReagents(Enum.BankType.Character)
-                        elseif C_Container and C_Container.DepositAllReagents then
-                            C_Container.DepositAllReagents()
-                        elseif C_Bank and C_Bank.DepositReagentBank then
-                            C_Bank.DepositReagentBank()
-                        elseif C_Container and C_Container.DepositReagentBank then
-                            C_Container.DepositReagentBank()
-                        elseif DepositReagentBank then
-                            DepositReagentBank()
-                        end
-                    </OnClick>
-                </Scripts>
-            </Button>
             <Button name="$parentClearButton" parentKey="clearButton">
                 <Size x="25" y="25"/>
                 <Anchors>


### PR DESCRIPTION
## Summary
- remove reagent deposit button from main bag bar
- drop bag-side logic for showing/hiding the deposit button

## Testing
- `luacheck src` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74fa99980832eae8b69bc05aeedae