### PR TITLE
Make deposit reagents button match default bank

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -124,12 +124,13 @@
                         GameTooltip:Hide()
                     </OnLeave>
                     <OnClick>
+                        local bankType = BankFrame and BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
                         if C_Bank and C_Bank.DepositAllReagents then
-                            C_Bank.DepositAllReagents(Enum.BankType.Character)
+                            C_Bank.DepositAllReagents(bankType or Enum.BankType and Enum.BankType.Character)
                         elseif C_Container and C_Container.DepositAllReagents then
                             C_Container.DepositAllReagents()
                         elseif C_Bank and C_Bank.DepositReagentBank then
-                            C_Bank.DepositReagentBank()
+                            C_Bank.DepositReagentBank(bankType)
                         elseif C_Container and C_Container.DepositReagentBank then
                             C_Container.DepositReagentBank()
                         elseif DepositReagentBank then

--- a/src/bank/BankFrame.lua
+++ b/src/bank/BankFrame.lua
@@ -97,12 +97,13 @@ function bankFrame:UpdateBankType()
     end
 
     if self.depositButton then
-        -- Display the deposit reagents button whenever the character bank
-        -- container is visible.  Rely on the bag's actual visibility rather
-        -- than the Blizzard bank type API which can return stale values while
-        -- the bank UI is loading, leaving the button hidden even though the
-        -- character bank is on screen.
-        local showDeposit = self.bankBag and self.bankBag:IsShown()
+        -- Display the deposit reagents button whenever either bank container
+        -- is visible.  Rely on the bags' actual visibility rather than the
+        -- Blizzard bank type API which can return stale values while the bank
+        -- UI is loading, leaving the button hidden even though the bank is on
+        -- screen.
+        local showDeposit = (self.bankBag and self.bankBag:IsShown()) or
+            (self.warbandBankBag and self.warbandBankBag:IsShown())
         self.depositButton:SetShown(showDeposit)
     end
 


### PR DESCRIPTION
## Summary
- Show deposit reagents button for either bank container
- Use active bank type when depositing all reagents

## Testing
- `luac -p src/bank/BankFrame.lua && xmllint --noout src/bank/Bank.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c7514fe284832eaecb10724a12be9e