### PR TITLE
Fix reagent deposit using updated bank API

### DIFF
--- a/src/bank/Bank.xml
+++ b/src/bank/Bank.xml
@@ -125,14 +125,15 @@
                     </OnLeave>
                     <OnClick>
                         local bankType = BankFrame and BankFrame.GetActiveBankType and BankFrame:GetActiveBankType()
-                        if C_Bank and C_Bank.DepositAllReagents then
-                            C_Bank.DepositAllReagents(bankType or Enum.BankType and Enum.BankType.Character)
-                        elseif C_Container and C_Container.DepositAllReagents then
-                            C_Container.DepositAllReagents()
-                        elseif C_Bank and C_Bank.DepositReagentBank then
+                        bankType = bankType or (Enum.BankType and Enum.BankType.Character)
+                        if C_Bank and C_Bank.DepositReagentBank then
                             C_Bank.DepositReagentBank(bankType)
                         elseif C_Container and C_Container.DepositReagentBank then
                             C_Container.DepositReagentBank()
+                        elseif C_Bank and C_Bank.DepositAllReagents then
+                            C_Bank.DepositAllReagents(bankType)
+                        elseif C_Container and C_Container.DepositAllReagents then
+                            C_Container.DepositAllReagents()
                         elseif DepositReagentBank then
                             DepositReagentBank()
                         end


### PR DESCRIPTION
## Summary
- call `DepositReagentBank` via `C_Bank` to ensure Deposit All Reagents button works for character and warband banks
- retain compatibility with older `C_Container` and legacy API fallbacks

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c752c37df4832eb2b53647e654eb1c