### PR TITLE
Add compatibility for upgrade icon detection

### DIFF
--- a/src/item/Item.lua
+++ b/src/item/Item.lua
@@ -205,15 +205,34 @@ local function UpdateCooldown(self)
     end
 end
 
+local function GetItemUpgradeStatus(self)
+    local bag = self:GetParent():GetID();
+    local slot = self:GetID();
+
+    if C_Container and C_Container.IsContainerItemAnUpgrade then
+        return C_Container.IsContainerItemAnUpgrade(bag, slot), true;
+    end
+
+    if C_Item and C_Item.IsItemAnUpgrade and ItemLocation and ItemLocation.CreateFromBagAndSlot then
+        local itemLocation = ItemLocation:CreateFromBagAndSlot(bag, slot);
+        if itemLocation and itemLocation:IsValid() then
+            return C_Item.IsItemAnUpgrade(itemLocation), true;
+        end
+    end
+
+    return false, false;
+end
+
 local function UpdateUpgrade(self)
     self.timeSinceUpgradeCheck = 0;
-    if not C_Container or not C_Container.IsContainerItemAnUpgrade then
+
+    local itemIsUpgrade, hasUpgradeAPI = GetItemUpgradeStatus(self);
+    if not hasUpgradeAPI then
         self.UpgradeIcon:SetShown(false);
         self:SetScript("OnUpdate", nil);
         return;
     end
 
-    local itemIsUpgrade = C_Container.IsContainerItemAnUpgrade(self:GetParent():GetID(), self:GetID());
     if ( itemIsUpgrade == nil ) then -- nil means not all the data was available to determine if this is an upgrade.
         self.UpgradeIcon:SetShown(false);
         self:SetScript("OnUpdate", OnItemUpdate);


### PR DESCRIPTION
## Summary
- add a helper to detect upgrade status using either the legacy container API or the new C_Item upgrade API
- hide the upgrade icon gracefully when neither API is available to avoid unnecessary update scripts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f430a9b534832eb95e3fa3aeafdee1